### PR TITLE
Dialog positioning improvements

### DIFF
--- a/src/background/js/environment.js
+++ b/src/background/js/environment.js
@@ -1,1 +1,1 @@
-var ENV = "production";
+var ENV = "development";

--- a/src/content/js/dialog.js
+++ b/src/content/js/dialog.js
@@ -270,7 +270,9 @@ App.autocomplete.dialog.liTemplate = '' +
     '{{#each elements}}' +
     '<li class="qt-item" data-id="{{id}}" title="{{{originalBody}}}">' +
     '<span class="qt-title">{{{title}}}</span>' +
+    '{{#if shortcut}}' +
     '<span class="qt-shortcut">{{{shortcut}}}</span>' +
+    '{{/if}}' +
     '<span class="qt-body">{{{body}}}</span>' +
     '</li>' +
     '{{/each}}' +

--- a/src/content/js/dialog.js
+++ b/src/content/js/dialog.js
@@ -60,7 +60,6 @@ App.autocomplete.dialog = {
         });
 
     },
-    // TODO(@ghinda): make dropdown position relative so on scrolling it will stay in right place
     create: function () {
 
         // Create only once in the root of the document
@@ -198,19 +197,16 @@ App.autocomplete.dialog = {
         $(this.searchSelector).focus();
         $(App.autocomplete.dialog.contentSelector).scrollTop();
 
-        // TODO in case we scroll the content element
-        //App.autocomplete.dialog.editor.removeEventListener('scroll', App.autocomplete.dialog.setDialogPosition);
-
-        console.log(App.autocomplete.dialog.editor);
-
+        // if we scroll the content element
+        
+        // remove it just in case we added it previously
+        App.autocomplete.dialog.editor.removeEventListener('scroll', App.autocomplete.dialog.setDialogPosition);
+        
         App.autocomplete.dialog.editor.addEventListener('scroll', App.autocomplete.dialog.setDialogPosition);
-
 
     },
     setDialogPosition: function() {
-
-        console.log($(window).scrollTop());
-
+        
         if(!App.autocomplete.dialog.isActive) {
             return;
         }
@@ -219,6 +215,9 @@ App.autocomplete.dialog = {
         var pageHeight = window.innerHeight;
         var scrollTop = $(window).scrollTop();
         var scrollLeft = $(window).scrollLeft();
+        
+        scrollTop += $(App.autocomplete.dialog.editor).scrollTop();
+        scrollLeft += $(App.autocomplete.dialog.editor).scrollLeft();
 
         var topPos = App.autocomplete.cursorPosition.absolute.top + App.autocomplete.cursorPosition.absolute.height;
         var bottomPos = 'auto';
@@ -233,9 +232,7 @@ App.autocomplete.dialog = {
             topPos = topPos - scrollTop;
         }
 
-        console.log(topPos);
-
-        $(this.dialogSelector).css({
+        $(App.autocomplete.dialog.dialogSelector).css({
             top: topPos,
             bottom: bottomPos,
             left: leftPos

--- a/src/content/js/dialog.js
+++ b/src/content/js/dialog.js
@@ -184,14 +184,49 @@ App.autocomplete.dialog = {
         App.autocomplete.dialog.isActive = true;
         App.autocomplete.dialog.isEmpty = true;
 
-        $(this.dialogSelector).css({
-            top: (cursorPosition.absolute.top + cursorPosition.absolute.height - $(window).scrollTop()) + 'px',
-            left: (cursorPosition.absolute.left + cursorPosition.absolute.width - $(window).scrollLeft()) + 'px'
+        // TODO call the positioning method on window scroll
+        // and active element scroll
+        // to fix issues with the dialog positioning and scrolling
+        // IF the dialog is active
+
+        var topPos = cursorPosition.absolute.top + cursorPosition.absolute.height;
+        var leftPos = cursorPosition.absolute.left + cursorPosition.absolute.width;
+
+        App.autocomplete.dialog.setDialogPosition({
+            top: topPos,
+            left: leftPos
         });
 
         $(this.dialogSelector).addClass('qt-dropdown-show');
         $(this.searchSelector).focus();
         $(App.autocomplete.dialog.contentSelector).scrollTop();
+    },
+    setDialogPosition: function(params) {
+
+        var dialogMaxHeight = 250;
+        var pageHeight = window.innerHeight;
+        var scrollTop = $(window).scrollTop();
+        var scrollLeft = $(window).scrollLeft();
+
+        var topPos = params.top;
+        var bottomPos = 'auto';
+        var leftPos = params.left - scrollLeft;
+
+        // check if we have enough space at the bottom
+        // for the maximum dialog height
+        if((pageHeight - params.top) < dialogMaxHeight) {
+            topPos = 'auto';
+            bottomPos = pageHeight - params.top + scrollTop;
+        } else {
+            topPos = topPos - scrollTop;
+        }
+
+        $(this.dialogSelector).css({
+            top: topPos,
+            bottom: bottomPos,
+            left: leftPos
+        });
+
     },
     selectItem: function (index) {
         if (App.autocomplete.dialog.isActive && !App.autocomplete.dialog.isEmpty) {

--- a/src/content/js/dialog.js
+++ b/src/content/js/dialog.js
@@ -156,12 +156,15 @@ App.autocomplete.dialog = {
             return '<span class="qt-search-highlight">' + match + '</span>';
         };
 
-        clonedElements.forEach(function (elem) {
-            elem.title = elem.title.replace(searchRe, highlightMatch);
-            elem.originalBody = elem.body;
-            elem.body = elem.body.replace(searchRe, highlightMatch);
-            elem.shortcut = elem.shortcut.replace(searchRe, highlightMatch);
-        });
+        // only match if we have a search string
+        if(App.autocomplete.cursorPosition.word.text) {
+            clonedElements.forEach(function (elem) {
+                elem.title = elem.title.replace(searchRe, highlightMatch);
+                elem.originalBody = elem.body;
+                elem.body = elem.body.replace(searchRe, highlightMatch);
+                elem.shortcut = elem.shortcut.replace(searchRe, highlightMatch);
+            });
+        }
 
         var content = Handlebars.compile(App.autocomplete.dialog.liTemplate)({
             elements: clonedElements
@@ -305,8 +308,8 @@ App.autocomplete.dialog.liTemplate = '' +
     '{{#each elements}}' +
     '<li class="qt-item" data-id="{{id}}" title="{{{originalBody}}}">' +
     '<span class="qt-title">{{{title}}}</span>' +
-    '{{#if shortcut}}' +
-    '<span class="qt-shortcut">{{{shortcut}}}</span>' +
+    '{{#if this.shortcut}}' +
+    '<span class="qt-shortcut">{{{this.shortcut}}}</span>' +
     '{{/if}}' +
     '<span class="qt-body">{{{body}}}</span>' +
     '</li>' +

--- a/src/content/js/dialog.js
+++ b/src/content/js/dialog.js
@@ -101,6 +101,11 @@ App.autocomplete.dialog = {
 
             });
         });
+
+        // when scrolling the element or the page
+        // set the autocomplete dialog position
+        window.addEventListener('scroll', App.autocomplete.dialog.setDialogPosition);
+
     },
     bindKeyboardEvents: function () {
         Mousetrap.bindGlobal('up', function (e) {
@@ -140,7 +145,7 @@ App.autocomplete.dialog = {
     populate: function (quicktexts) {
         App.autocomplete.quicktexts = quicktexts;
         if (!App.autocomplete.dialog.isActive) {
-            App.autocomplete.dialog.show(App.autocomplete.cursorPosition);
+            App.autocomplete.dialog.show();
         }
 
 
@@ -176,8 +181,8 @@ App.autocomplete.dialog = {
         // Set first element active
         App.autocomplete.dialog.selectItem(0);
     },
-    show: function (cursorPosition) {
-       // get current focused element - the editor
+    show: function () {
+        // get current focused element - the editor
         App.autocomplete.dialog.editor = document.activeElement;
 
         var selection = window.getSelection();
@@ -187,42 +192,48 @@ App.autocomplete.dialog = {
         App.autocomplete.dialog.isActive = true;
         App.autocomplete.dialog.isEmpty = true;
 
-        // TODO call the positioning method on window scroll
-        // and active element scroll
-        // to fix issues with the dialog positioning and scrolling
-        // IF the dialog is active
-
-        var topPos = cursorPosition.absolute.top + cursorPosition.absolute.height;
-        var leftPos = cursorPosition.absolute.left + cursorPosition.absolute.width;
-
-        App.autocomplete.dialog.setDialogPosition({
-            top: topPos,
-            left: leftPos
-        });
+        App.autocomplete.dialog.setDialogPosition();
 
         $(this.dialogSelector).addClass('qt-dropdown-show');
         $(this.searchSelector).focus();
         $(App.autocomplete.dialog.contentSelector).scrollTop();
+
+        // TODO in case we scroll the content element
+        //App.autocomplete.dialog.editor.removeEventListener('scroll', App.autocomplete.dialog.setDialogPosition);
+
+        console.log(App.autocomplete.dialog.editor);
+
+        App.autocomplete.dialog.editor.addEventListener('scroll', App.autocomplete.dialog.setDialogPosition);
+
+
     },
-    setDialogPosition: function(params) {
+    setDialogPosition: function() {
+
+        console.log($(window).scrollTop());
+
+        if(!App.autocomplete.dialog.isActive) {
+            return;
+        }
 
         var dialogMaxHeight = 250;
         var pageHeight = window.innerHeight;
         var scrollTop = $(window).scrollTop();
         var scrollLeft = $(window).scrollLeft();
 
-        var topPos = params.top;
+        var topPos = App.autocomplete.cursorPosition.absolute.top + App.autocomplete.cursorPosition.absolute.height;
         var bottomPos = 'auto';
-        var leftPos = params.left - scrollLeft;
+        var leftPos = App.autocomplete.cursorPosition.absolute.left + App.autocomplete.cursorPosition.absolute.width - scrollLeft;
 
         // check if we have enough space at the bottom
         // for the maximum dialog height
-        if((pageHeight - params.top) < dialogMaxHeight) {
+        if((pageHeight - App.autocomplete.cursorPosition.absolute.top) < dialogMaxHeight) {
             topPos = 'auto';
-            bottomPos = pageHeight - params.top + scrollTop;
+            bottomPos = pageHeight - App.autocomplete.cursorPosition.absolute.top + scrollTop;
         } else {
             topPos = topPos - scrollTop;
         }
+
+        console.log(topPos);
 
         $(this.dialogSelector).css({
             top: topPos,


### PR DESCRIPTION
Improvements on the dialog positioning functionality.

* If there isn't enough space at the bottom of the window (between the point where the caret is and the bottom of the viewport) to fit the dialog, the dialog will be placed at the top of the caret.
* The dialog's position, when the dialog is visible, will change when scrolling the page or the content element. 

This doesn't work in Gmail, because it relies on the standard element `scroll` event. Gmail seems to be using custom js-based elements for scrolling, and not standard `overflow: auto` functionality.

Another small fix:
* Don't display an empty `.qt-shortcut` element in the quicktexts listing in the dialog, if the qt does not have a shortcut set.