### PR TITLE
Fix #131 Subject Variable Delay

### DIFF
--- a/src/content/js/plugins/gmail.js
+++ b/src/content/js/plugins/gmail.js
@@ -73,7 +73,7 @@ App.plugin('gmail', (function() {
             bcc = $container.find('input[name=bcc]').toArray().map(function (a) {
                 return a.value;
             });
-            subject = $container.find('input[name=subject]').val().replace(/^Re: /, "");
+            subject = $container.find('input[name=subjectbox]').val().replace(/^Re: /, "");
 
         } else {
 


### PR DESCRIPTION
Don't use GMail's hidden fields for the Subject string. It's delayed.