### PR TITLE
Add an option for case sensitive search

### DIFF
--- a/src/common/storage.js
+++ b/src/common/storage.js
@@ -101,7 +101,7 @@ var Settings = {
             qaBtn: {
                 enabled: true,
                 shownPostInstall: false,
-                caseSensitiveSearch: true
+                caseSensitiveSearch: false
             },
             keyboard: {
                 enabled: true,

--- a/src/common/storage.js
+++ b/src/common/storage.js
@@ -100,7 +100,8 @@ var Settings = {
             },
             qaBtn: {
                 enabled: true,
-                shownPostInstall: false
+                shownPostInstall: false,
+                caseSensitiveSearch: false
             },
             keyboard: {
                 enabled: true,

--- a/src/common/storage.js
+++ b/src/common/storage.js
@@ -101,7 +101,7 @@ var Settings = {
             qaBtn: {
                 enabled: true,
                 shownPostInstall: false,
-                caseSensitiveSearch: false
+                caseSensitiveSearch: true
             },
             keyboard: {
                 enabled: true,

--- a/src/content/js/index.js
+++ b/src/content/js/index.js
@@ -14,6 +14,7 @@ var App = {
     autocomplete: {},
     settings: {
         suggestions_enabled: false,
+        case_sensitive_search: false,
 
         // Get template filtered out by shortcut
         getQuicktextsShortcut: function (text, callback) {
@@ -73,10 +74,19 @@ var App = {
                         }
                         // we have some text, do the filtering
                         if (text) {
-                            if (t.shortcut.indexOf(text) !== -1 ||
-                                t.title.indexOf(text) !== -1 ||
-                                t.body.indexOf(text) !== -1) {
-                                templates.push(t);
+                            if (App.settings.case_sensitive_search) {
+                                if (t.shortcut.toLowerCase().indexOf(text.toLowerCase()) !== -1 ||
+                                    t.title.toLowerCase().indexOf(text.toLowerCase()) !== -1 ||
+                                    t.body.toLowerCase().indexOf(text.toLowerCase()) !== -1) {
+                                    templates.push(t);
+                                }
+                            }
+                            else {
+                                if (t.shortcut.indexOf(text) !== -1 ||
+                                    t.title.indexOf(text) !== -1 ||
+                                    t.body.indexOf(text) !== -1) {
+                                    templates.push(t);
+                                }
                             }
                         } else { // no text, get all
                             templates.push(t);
@@ -229,6 +239,8 @@ App.init = function (settings, doc) {
     App.settings.suggestions_enabled = settings.suggestions.enabled;
     // Check if we should use editor markup
     App.settings.editor_enabled = settings.editor.enabled;
+    // Check if case sensitive search is enable
+    App.settings.case_sensitive_search = settings.qaBtn.caseSensitiveSearch;
 
     var blacklistPrivate = [
         'https://gorgias.io',

--- a/src/content/js/index.js
+++ b/src/content/js/index.js
@@ -74,21 +74,13 @@ var App = {
                         }
                         // we have some text, do the filtering
                         if (text) {
-                            if (App.settings.case_sensitive_search) {
-                                if (t.shortcut.toLowerCase().indexOf(text.toLowerCase()) !== -1 ||
-                                    t.title.toLowerCase().indexOf(text.toLowerCase()) !== -1 ||
-                                    t.body.toLowerCase().indexOf(text.toLowerCase()) !== -1) {
-                                    templates.push(t);
-                                }
+                            var templateRegex = new RegExp(text, App.settings.case_sensitive_search ? 'i' : '');
+
+                            if (templateRegex.test([t.shortcut, t.title, t.body].join())) {
+                                templates.push(t);
                             }
-                            else {
-                                if (t.shortcut.indexOf(text) !== -1 ||
-                                    t.title.indexOf(text) !== -1 ||
-                                    t.body.indexOf(text) !== -1) {
-                                    templates.push(t);
-                                }
-                            }
-                        } else { // no text, get all
+                        }
+                        else { // no text, get all
                             templates.push(t);
                         }
                     }
@@ -239,7 +231,7 @@ App.init = function (settings, doc) {
     App.settings.suggestions_enabled = settings.suggestions.enabled;
     // Check if we should use editor markup
     App.settings.editor_enabled = settings.editor.enabled;
-    // Check if case sensitive search is enable
+    // Check if case sensitive search is enabled
     App.settings.case_sensitive_search = settings.qaBtn.caseSensitiveSearch;
 
     var blacklistPrivate = [

--- a/src/content/js/index.js
+++ b/src/content/js/index.js
@@ -14,7 +14,7 @@ var App = {
     autocomplete: {},
     settings: {
         suggestions_enabled: false,
-        case_sensitive_search: false,
+        case_sensitive_search: true,
 
         // Get template filtered out by shortcut
         getQuicktextsShortcut: function (text, callback) {
@@ -74,7 +74,7 @@ var App = {
                         }
                         // we have some text, do the filtering
                         if (text) {
-                            var templateRegex = new RegExp(text, App.settings.case_sensitive_search ? 'i' : '');
+                            var templateRegex = new RegExp(text, App.settings.case_sensitive_search ? '' : 'i');
 
                             if (templateRegex.test([t.shortcut, t.title, t.body].join())) {
                                 templates.push(t);

--- a/src/content/js/index.js
+++ b/src/content/js/index.js
@@ -14,7 +14,7 @@ var App = {
     autocomplete: {},
     settings: {
         suggestions_enabled: false,
-        case_sensitive_search: true,
+        case_sensitive_search: false,
 
         // Get template filtered out by shortcut
         getQuicktextsShortcut: function (text, callback) {
@@ -74,9 +74,14 @@ var App = {
                         }
                         // we have some text, do the filtering
                         if (text) {
-                            var templateRegex = new RegExp(text, App.settings.case_sensitive_search ? '' : 'i');
-
-                            if (templateRegex.test([t.shortcut, t.title, t.body].join())) {
+                            var findText = function (pattern) {
+                                return App.settings.case_sensitive_search
+                                    ? pattern.indexOf(text) !== -1
+                                    : pattern.toLowerCase().indexOf(text.toLowerCase()) !== -1;
+                            }
+                            if (findText(t.shortcut, text) ||
+                                findText(t.title, text) ||
+                                findText(t.body, text)) {
                                 templates.push(t);
                             }
                         }

--- a/src/pages/views/settings.html
+++ b/src/pages/views/settings.html
@@ -48,7 +48,7 @@
     <div class="checkbox" ng-show="settings.dialog.enabled">
         <label for="caseSensitive">
             <input type="checkbox" id="caseSensitive" ng-model="settings.qaBtn.caseSensitiveSearch" ng-change="updateSettings()"/>
-            Enable Case Sensitive Search
+            Disable Case Sensitive Search
         </label>
         <span class="fa fa-question-circle" data-toggle="tooltip" data-placement="bottom"
               data-original-title="Enable case sensitive search in the search dialog"></span>

--- a/src/pages/views/settings.html
+++ b/src/pages/views/settings.html
@@ -48,7 +48,7 @@
     <div class="checkbox" ng-show="settings.dialog.enabled">
         <label for="caseSensitive">
             <input type="checkbox" id="caseSensitive" ng-model="settings.qaBtn.caseSensitiveSearch" ng-change="updateSettings()"/>
-            Disable Case Sensitive Search
+            Enable Case Sensitive Search
         </label>
         <span class="fa fa-question-circle" data-toggle="tooltip" data-placement="bottom"
               data-original-title="Enable case sensitive search in the search dialog"></span>

--- a/src/pages/views/settings.html
+++ b/src/pages/views/settings.html
@@ -45,6 +45,14 @@
         <span class="fa fa-question-circle" data-toggle="tooltip" data-placement="bottom"
               data-original-title="The Quick Access button is placed in the right corner of input fields"></span>
     </div>
+    <div class="checkbox" ng-show="settings.dialog.enabled">
+        <label for="caseSensitive">
+            <input type="checkbox" id="caseSensitive" ng-model="settings.qaBtn.caseSensitiveSearch" ng-change="updateSettings()"/>
+            Enable Case Sensitive Search
+        </label>
+        <span class="fa fa-question-circle" data-toggle="tooltip" data-placement="bottom"
+              data-original-title="Enable case sensitive search in the search dialog"></span>
+    </div>
     <div class="form-group" ng-show="settings.dialog.enabled">
         <label for="dialog-shortcut" data-toggle="tooltip" data-placement="bottom"
                data-original-title="Setup keyboard shortcut that triggers the auto-complete dialog">


### PR DESCRIPTION
Add a _Enable Case Sensitive Search_ checkbox in _Auto-complete Dialog_ section in settings to enable case sensitive search in the dialog search box

Closes #123

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gorgias/gorgias-chrome/198)
<!-- Reviewable:end -->
