### PR TITLE
Show more fields: Subject, To, CC, BCC

### DIFF
--- a/src/background/css/bootstrap-chrome.styl
+++ b/src/background/css/bootstrap-chrome.styl
@@ -275,6 +275,17 @@ input[type='password'],
     border-bottom: 1px solid $grey1;
 }
 
+.btn-link,
+.btn-link:hover {
+    padding: emCalc(4) 0;
+    border: 0 !important;
+    background: transparent;
+    box-shadow: none;
+
+    color: $link !important;
+    text-shadow: 0;
+}
+
 /* Modal
  */
 .modal-dialog.thin-modal {

--- a/src/background/css/list.styl
+++ b/src/background/css/list.styl
@@ -180,3 +180,18 @@
         margin-top: 10px;
     }
 }
+
+/* flexible grid for extra fields in quicktext form
+ */
+.form-group-grid {
+    display: flex;
+}
+
+.form-group-grid .form-group {
+    flex: 1;
+}
+
+.form-group-grid .form-group:not(:last-child) {
+    margin-right: 15px;
+}
+

--- a/src/background/js/controllers/includes/template_form.js
+++ b/src/background/js/controllers/includes/template_form.js
@@ -12,7 +12,9 @@ gApp.controller('TemplateFormCtrl',
         // fields that show up under `show more fields`
         var extraFields = [
             'subject',
-            'to'
+            'to',
+            'cc',
+            'bcc'
         ];
 
         // used by extra fields button,
@@ -288,6 +290,13 @@ gApp.controller('TemplateFormCtrl',
                 }
             }
 
+            // delete extra fields with blank values,
+            // to not show them again on edit.
+            extraFields.forEach(function (field) {
+                if (typeof self.selectedTemplate[field] === 'string' && self.selectedTemplate[field].trim() === '') {
+                    delete self.selectedTemplate[field]
+                }
+            })
 
             TemplateService.quicktexts().then(function (templates) {
                 if (self.selectedTemplate.shortcut) {

--- a/src/background/js/controllers/includes/template_form.js
+++ b/src/background/js/controllers/includes/template_form.js
@@ -9,6 +9,41 @@ gApp.controller('TemplateFormCtrl',
         self.extended = false;
         self.showHTMLSource = false;
 
+        // fields that show up under `show more fields`
+        var extraFields = [
+            'subject',
+            'to'
+        ];
+
+        // used by extra fields button,
+        // if any extra fields are hidden.
+        // shown by default.
+        self.extraFields = true;
+
+        // checks if a field has content,
+        // and should be visible.
+        self.extraFieldContent = function (field) {
+            return (typeof field === 'string')
+        };
+
+        // check if any extra fields are hidden
+        var checkHiddenExtraFields = function () {
+            return extraFields.some(function (field) {
+                return !self.extraFieldContent(self.selectedTemplate[field]);
+            });
+        };
+
+        self.showExtraFields = function () {
+            // add blank content
+            extraFields.forEach(function (field) {
+                if (!self.extraFieldContent(self.selectedTemplate[field])) {
+                    self.selectedTemplate[field] = '';
+                }
+            });
+
+            self.extraFields = false;
+        };
+
         var loadEditor = function () {
             self.showHTMLSource = false;
             if (editor) { //already loaded
@@ -163,12 +198,12 @@ gApp.controller('TemplateFormCtrl',
                     var defaults = {
                         'id': '',
                         'remote_id': '',
-                        'subject': '',
                         'shortcut': '',
                         'title': '',
                         'tags': '',
                         'body': '',
-                        'attachments': []
+                        'attachments': [],
+                        'subject': ''
                     };
 
                     id = id ? id : $routeParams.id;
@@ -184,6 +219,9 @@ gApp.controller('TemplateFormCtrl',
                                 $('#qt-tags')[0].selectize.addItem($.trim(FilterTagService.filterTags[0]));
                             }
                         }
+
+                        // do we need to show the `show more fields` btn
+                        self.extraFields = checkHiddenExtraFields()
                     } else if (id) {
                         // update template
                         TemplateService.get(id).then(function (r) {
@@ -194,6 +232,8 @@ gApp.controller('TemplateFormCtrl',
                             $.each(self.selectedTemplate.tags.split(','), function (_, tag) {
                                 $('#qt-tags')[0].selectize.addItem($.trim(tag));
                             });
+
+                            self.extraFields = checkHiddenExtraFields()
                         });
                     }
                 });

--- a/src/background/js/controllers/includes/template_form.js
+++ b/src/background/js/controllers/includes/template_form.js
@@ -35,6 +35,18 @@ gApp.controller('TemplateFormCtrl',
             });
         };
 
+        // clean empty extra fields, for backwards compatibility.
+        // (eg. quicktexts saved with empty subject)
+        var cleanExtraFields = function (qt) {
+            extraFields.some(function (field) {
+                if (typeof qt[field] === 'string' && qt[field].trim() === '') {
+                    delete qt[field]
+                }
+            });
+
+            return qt
+        }
+
         self.showExtraFields = function () {
             // add blank content
             extraFields.forEach(function (field) {
@@ -204,8 +216,7 @@ gApp.controller('TemplateFormCtrl',
                         'title': '',
                         'tags': '',
                         'body': '',
-                        'attachments': [],
-                        'subject': ''
+                        'attachments': []
                     };
 
                     id = id ? id : $routeParams.id;
@@ -223,11 +234,13 @@ gApp.controller('TemplateFormCtrl',
                         }
 
                         // do we need to show the `show more fields` btn
-                        self.extraFields = checkHiddenExtraFields()
+                        self.extraFields = checkHiddenExtraFields();
                     } else if (id) {
                         // update template
                         TemplateService.get(id).then(function (r) {
-                            self.selectedTemplate = angular.copy(r);
+
+                            self.selectedTemplate = angular.copy(cleanExtraFields(r));
+
                             if (editor) {
                                 editor.setHTML(self.selectedTemplate.body);
                             }
@@ -235,7 +248,7 @@ gApp.controller('TemplateFormCtrl',
                                 $('#qt-tags')[0].selectize.addItem($.trim(tag));
                             });
 
-                            self.extraFields = checkHiddenExtraFields()
+                            self.extraFields = checkHiddenExtraFields();
                         });
                     }
                 });

--- a/src/content/js/autocomplete.js
+++ b/src/content/js/autocomplete.js
@@ -361,9 +361,22 @@ App.autocomplete.replaceWith = function (params) {
     // in the dialog otherwise, instead of the editor
     App.autocomplete.focusEditor(params.element, setText);
 
-    // set subject field
-    if (params.quicktext.subject) {
-        App.activePlugin.setTitle(params);
+    // set extra fields
+    var fields = [
+        'subject',
+        'to'
+    ];
+
+    if (typeof App.activePlugin.setField === 'function') {
+        fields.forEach(function (field) {
+            if (params.quicktext[field]) {
+                App.activePlugin.setField({
+                    element: params.element,
+                    field: field,
+                    value: params.quicktext[field]
+                });
+            }
+        });
     }
 
     // updates stats

--- a/src/content/js/autocomplete.js
+++ b/src/content/js/autocomplete.js
@@ -364,7 +364,9 @@ App.autocomplete.replaceWith = function (params) {
     // set extra fields
     var fields = [
         'subject',
-        'to'
+        'to',
+        'cc',
+        'bcc'
     ];
 
     if (typeof App.activePlugin.setField === 'function') {

--- a/src/content/js/autocomplete.js
+++ b/src/content/js/autocomplete.js
@@ -198,20 +198,15 @@ App.autocomplete.getCursorPosition = function (element) {
 
 App.autocomplete.replaceWith = function (params) {
 
-    var doc = params.element.ownerDocument;
-
     var word = App.autocomplete.cursorPosition.word;
     var replacement = '';
 
     App.autocomplete.justCompleted = true; // the idea is that we don't want any completion to popup after we just completed
 
-    var setText = function () {
+    var setText = function (vars) {
+        var doc = params.element.ownerDocument;
 
-        App.activePlugin.getData({
-            element: params.element
-        }, function (err, response) {
-
-            var parsedTemplate = Handlebars.compile(params.quicktext.body)(PrepareVars(response));
+        var parsedTemplate = Handlebars.compile(params.quicktext.body)(params.data);
 
             if (App.autocomplete.isContentEditable(params.element)) {
 
@@ -227,7 +222,7 @@ App.autocomplete.replaceWith = function (params) {
                 // the type of node
                 // https://developer.mozilla.org/en-US/docs/Web/API/range.setStart
                 var focusNode = params.focusNode;
-                if (focusNode === null) {
+                if (!document.body.contains(focusNode)) {
                     focusNode = selection.focusNode;
                 }
 
@@ -262,7 +257,7 @@ App.autocomplete.replaceWith = function (params) {
                 var qtNode = range.createContextualFragment(replacement);
                 var lastQtChild = qtNode.lastChild;
 
-                if (params.quicktext.attachments && params.quicktext.attachments.length > 0 && response && response.plugin === 'gmail') {
+                if (params.quicktext.attachments && params.quicktext.attachments.length > 0 && vars && vars.plugin === 'gmail') {
                     if (params.quicktext.attachments.length) //in case there was attachments in that quicktext that have been removed then..
                         params.quicktext.attachments.map(function (attachment, index) {
                             App.activePlugin.setAttachment(attachment, range);
@@ -348,38 +343,39 @@ App.autocomplete.replaceWith = function (params) {
                 $textarea[0].setSelectionRange(cursorOffset, cursorOffset);
 
             }
+    };
 
-        });
+    var insertQt = function (params) {
+        return function () {
+            setText(params.data);
 
+            if (typeof App.activePlugin.after === 'function') {
+                App.activePlugin.after(params);
+            }
+        };
     };
 
     App.autocomplete.dialog.close();
 
-    // we need the callback because the editor
-    // doesn't get the focus right-away.
-    // so window.getSelection() returns the search field
-    // in the dialog otherwise, instead of the editor
-    App.autocomplete.focusEditor(params.element, setText);
+    App.activePlugin.getData({
+        element: params.element
+    }, function (err, vars) {
+        // add parsed vars to params
+        params.data = PrepareVars(vars);
 
-    // set extra fields
-    var fields = [
-        'subject',
-        'to',
-        'cc',
-        'bcc'
-    ];
+        if (typeof App.activePlugin.before === 'function') {
+            App.activePlugin.before(params, function (err, params) {
+                // we need the callback because the editor
+                // doesn't get the focus right-away.
+                // so window.getSelection() returns the search field
+                // in the dialog otherwise, instead of the editor
+                App.autocomplete.focusEditor(params.element, insertQt(params));
+            });
+            return;
+        }
 
-    if (typeof App.activePlugin.setField === 'function') {
-        fields.forEach(function (field) {
-            if (params.quicktext[field]) {
-                App.activePlugin.setField({
-                    element: params.element,
-                    field: field,
-                    value: params.quicktext[field]
-                });
-            }
-        });
-    }
+        App.autocomplete.focusEditor(params.element, insertQt(params));
+    });
 
     // updates stats
     App.settings.stats('words', params.quicktext.body.split(' ').length, function () {

--- a/src/content/js/index.js
+++ b/src/content/js/index.js
@@ -162,9 +162,6 @@ var App = {
 // the active plugin, based on the plugin.init response
 // blank at first
 App.activePlugin = {
-    setField: function (params, callback) {
-        callback();
-    },
     getData: function (params, callback) {
         callback();
     },

--- a/src/content/js/index.js
+++ b/src/content/js/index.js
@@ -162,7 +162,7 @@ var App = {
 // the active plugin, based on the plugin.init response
 // blank at first
 App.activePlugin = {
-    setTitle: function (params, callback) {
+    setField: function (params, callback) {
         callback();
     },
     getData: function (params, callback) {
@@ -182,8 +182,7 @@ App.plugin = function (id, obj) {
     // check if plugin has all the required methods
     var requiredMethods = [
         'init',
-        'getData',
-        'setTitle'
+        'getData'
     ];
 
     // mix in the plugin

--- a/src/content/js/plugins/desk.js
+++ b/src/content/js/plugins/desk.js
@@ -147,15 +147,10 @@ App.plugin('desk', (function () {
         return callback(null, vars)
     };
 
-    var setTitle = function () {
-
-    };
-
 
     return {
         init: init,
-        getData: getData,
-        setTitle: setTitle
+        getData: getData
     };
 
 })());

--- a/src/content/js/plugins/facebook.js
+++ b/src/content/js/plugins/facebook.js
@@ -77,14 +77,6 @@ App.plugin('facebook', (function() {
 
     };
 
-    var setTitle = function(params, callback) {
-        // there is no title on Facebook
-        if(callback) {
-            callback(null, {});
-        }
-
-    };
-
     var init = function(params, callback) {
         var url = '.facebook.com/';
         var activateExtension = false;
@@ -104,8 +96,7 @@ App.plugin('facebook', (function() {
 
     return {
         init: init,
-        getData: getData,
-        setTitle: setTitle
+        getData: getData
     }
 
 })());

--- a/src/content/js/plugins/fastmail.js
+++ b/src/content/js/plugins/fastmail.js
@@ -77,8 +77,12 @@ App.plugin('fastmail', (function() {
 
     };
 
+    var isHidden = function (el) {
+        return (el.offsetParent === null)
+    }
+
     var before = function (params, callback) {
-        var $parent = $(params.element).closest('#compose')
+        var $parent = $(params.element).closest('.v-Compose')
 
         if (params.quicktext.subject) {
             var parsedSubject = Handlebars.compile(params.quicktext.subject)(PrepareVars(params.data));
@@ -99,11 +103,16 @@ App.plugin('fastmail', (function() {
         if (params.quicktext.cc) {
             var parsedCc = Handlebars.compile(params.quicktext.cc)(PrepareVars(params.data));
 
-            var $ccBtn = $btns.eq(0);
-            // dispatchEvent or trigger do not work
-            $ccBtn.get(0).click();
-
             var $ccField = $('textarea[id$="cc-input"]', $parent);
+
+            // only if the cc field is hidden,
+            // because the same button is used to show/hide the field.
+            if (isHidden($ccField.get(0))) {
+                var $ccBtn = $btns.eq(0);
+                // dispatchEvent or trigger do not work
+                $ccBtn.get(0).click();
+            }
+
             $ccField.val(parsedCc);
 
             $ccField.get(0).dispatchEvent(new Event('input'));
@@ -112,11 +121,15 @@ App.plugin('fastmail', (function() {
         if (params.quicktext.bcc) {
             var parsedBcc = Handlebars.compile(params.quicktext.bcc)(PrepareVars(params.data));
 
-            var $bccBtn = $btns.eq(1);
-            // dispatchEvent or trigger do not work
-            $bccBtn.get(0).click();
-
             var $bccField = $('textarea[id$="bcc-input"]', $parent);
+
+            // only if the bcc field is hidden
+            if (isHidden($bccField.get(0))) {
+                var $bccBtn = $btns.eq(1);
+                // dispatchEvent or trigger do not work
+                $bccBtn.get(0).click();
+            }
+
             $bccField.val(parsedBcc);
 
             $bccField.get(0).dispatchEvent(new Event('input'));

--- a/src/content/js/plugins/fastmail.js
+++ b/src/content/js/plugins/fastmail.js
@@ -87,64 +87,40 @@ App.plugin('fastmail', (function() {
 
         if (params.quicktext.to) {
             var parsedTo = Handlebars.compile(params.quicktext.to)(PrepareVars(params.data));
-            var $toField = $('#v112-to-input', $parent)
+            var $toField = $('textarea[id$="to-input"]', $parent)
             $toField.val(parsedTo);
-//             $toField.trigger('keyup');
-//             $toField.trigger('blur');
 
-//             var e1 = $.Event('keydown', {
-//                 keyCode: 32 //space
-//             });
-//             var e2 = $.Event('keypress', {
-//                 keyCode: 32 //space
-//             });
-//             var e3 = $.Event('keyup', {
-//                 keyCode: 32 //space
-//             });
-//             $toField.focus()
-//             $toField.trigger(e1);
-//             $toField.trigger(e2);
-//             $toField.trigger(e3);
-
-//             $toField.trigger('change');
-
-//             $toField.trigger('focus');
-//             $toField.trigger('blur');
-//             $toField.trigger('keyup');
-//             $toField.trigger('keydown');
-//             $toField.trigger('keypress');
-//             $toField.trigger('change');
+            // jQuery's trigger does not work
+            $toField.get(0).dispatchEvent(new Event('input'));
         }
 
-//         if (params.quicktext.to ||
-//             params.quicktext.cc ||
-//             params.quicktext.bcc
-//         ) {
-//             // click the receipients row.
-//             // a little jumpy,
-//             // but the only to way to show the new value.
-//             $parent.find('.aoD.hl').trigger('focus');
-//         }
+        var $btns = $('.v-Compose-addCcBcc .u-subtleLink', $parent);
 
-//         var $btns = $('.v-Compose-addCcBcc u-subtleLink', $parent)
+        if (params.quicktext.cc) {
+            var parsedCc = Handlebars.compile(params.quicktext.cc)(PrepareVars(params.data));
 
-//         if (params.quicktext.cc) {
-//             var parsedCc = Handlebars.compile(params.quicktext.cc)(PrepareVars(params.data));
-//
-//             // click the cc button
-//             $parent.find('.aB.gQ.pE').trigger('click');
-//
-//             $parent.find('textarea[name=cc]').val(parsedCc);
-//         }
-//
-//         if (params.quicktext.bcc) {
-//             var parsedBcc = Handlebars.compile(params.quicktext.bcc)(PrepareVars(params.data));
-//
-//             // click the bcc button
-//             $parent.find('.aB.gQ.pB').trigger('click');
-//
-//             $parent.find('textarea[name=bcc]').val(parsedBcc);
-//         }
+            var $ccBtn = $btns.eq(0);
+            // dispatchEvent or trigger do not work
+            $ccBtn.get(0).click();
+
+            var $ccField = $('textarea[id$="cc-input"]', $parent);
+            $ccField.val(parsedCc);
+
+            $ccField.get(0).dispatchEvent(new Event('input'));
+        }
+
+        if (params.quicktext.bcc) {
+            var parsedBcc = Handlebars.compile(params.quicktext.bcc)(PrepareVars(params.data));
+
+            var $bccBtn = $btns.eq(1);
+            // dispatchEvent or trigger do not work
+            $bccBtn.get(0).click();
+
+            var $bccField = $('textarea[id$="bcc-input"]', $parent);
+            $bccField.val(parsedBcc);
+
+            $bccField.get(0).dispatchEvent(new Event('input'));
+        }
 
         if (callback) {
             callback(null, params);

--- a/src/content/js/plugins/fastmail.js
+++ b/src/content/js/plugins/fastmail.js
@@ -77,17 +77,78 @@ App.plugin('fastmail', (function() {
 
     };
 
-    var setTitle = function(params, callback) {
+    var before = function (params, callback) {
+        var $parent = $(params.element).closest('#compose')
 
-        var response = {};
-
-        var $subjectField = $('input[id$="subject-input"]');
-        $subjectField.val(params.quicktext.subject);
-
-        if(callback) {
-            callback(null, response);
+        if (params.quicktext.subject) {
+            var parsedSubject = Handlebars.compile(params.quicktext.subject)(PrepareVars(params.data));
+            $('input[id$="subject-input"]', $parent).val(parsedSubject);
         }
 
+        if (params.quicktext.to) {
+            var parsedTo = Handlebars.compile(params.quicktext.to)(PrepareVars(params.data));
+            var $toField = $('#v112-to-input', $parent)
+            $toField.val(parsedTo);
+//             $toField.trigger('keyup');
+//             $toField.trigger('blur');
+
+//             var e1 = $.Event('keydown', {
+//                 keyCode: 32 //space
+//             });
+//             var e2 = $.Event('keypress', {
+//                 keyCode: 32 //space
+//             });
+//             var e3 = $.Event('keyup', {
+//                 keyCode: 32 //space
+//             });
+//             $toField.focus()
+//             $toField.trigger(e1);
+//             $toField.trigger(e2);
+//             $toField.trigger(e3);
+
+//             $toField.trigger('change');
+
+//             $toField.trigger('focus');
+//             $toField.trigger('blur');
+//             $toField.trigger('keyup');
+//             $toField.trigger('keydown');
+//             $toField.trigger('keypress');
+//             $toField.trigger('change');
+        }
+
+//         if (params.quicktext.to ||
+//             params.quicktext.cc ||
+//             params.quicktext.bcc
+//         ) {
+//             // click the receipients row.
+//             // a little jumpy,
+//             // but the only to way to show the new value.
+//             $parent.find('.aoD.hl').trigger('focus');
+//         }
+
+//         var $btns = $('.v-Compose-addCcBcc u-subtleLink', $parent)
+
+//         if (params.quicktext.cc) {
+//             var parsedCc = Handlebars.compile(params.quicktext.cc)(PrepareVars(params.data));
+//
+//             // click the cc button
+//             $parent.find('.aB.gQ.pE').trigger('click');
+//
+//             $parent.find('textarea[name=cc]').val(parsedCc);
+//         }
+//
+//         if (params.quicktext.bcc) {
+//             var parsedBcc = Handlebars.compile(params.quicktext.bcc)(PrepareVars(params.data));
+//
+//             // click the bcc button
+//             $parent.find('.aB.gQ.pB').trigger('click');
+//
+//             $parent.find('textarea[name=bcc]').val(parsedBcc);
+//         }
+
+        if (callback) {
+            callback(null, params);
+        }
     };
 
     var init = function(params, callback) {
@@ -113,7 +174,7 @@ App.plugin('fastmail', (function() {
     return {
         init: init,
         getData: getData,
-        setTitle: setTitle
+        before: before
     }
 
 })());

--- a/src/content/js/plugins/gmail.js
+++ b/src/content/js/plugins/gmail.js
@@ -125,21 +125,36 @@ App.plugin('gmail', (function () {
 
     var setField = function (params, callback) {
         getData(params, function (_, vars) {
-            var parsedContent = Handlebars.compile(params.value)(PrepareVars(vars));
+            var parsedValue = Handlebars.compile(params.value)(PrepareVars(vars));
             var $parent = $(params.element).closest('table.aoP')
 
             if (params.field === 'subject') {
-                var $subjectField = $parent.find('input[name=subjectbox]');
-                $subjectField.val(parsedContent);
+                $parent.find('input[name=subjectbox]').val(parsedValue);
+            }
+
+            if ([ 'to', 'cc', 'bcc' ].indexOf(params.field) !== -1) {
+                // click the receipients row.
+                // a little jumpy,
+                // but the only to way to show the new value.
+                $parent.find('.aoD.hl').trigger('focus');
             }
 
             if (params.field === 'to') {
-                var $toField = $parent.find('textarea[name=to]');
-                $toField.val(parsedContent);
+                $parent.find('textarea[name=to]').val(parsedValue);
+            }
 
-                // a little jumpy,
-                // but the only to way to force showing the new value.
-                $parent.find('.aoD.hl').trigger('focus');
+            if (params.field === 'cc') {
+                // click the cc button
+                $parent.find('.aB.gQ.pE').trigger('click');
+
+                $parent.find('textarea[name=cc]').val(parsedValue);
+            }
+
+            if (params.field === 'bcc') {
+                // click the bcc button
+                $parent.find('.aB.gQ.pB').trigger('click');
+
+                $parent.find('textarea[name=bcc]').val(parsedValue);
             }
 
             if (callback) {

--- a/src/content/js/plugins/gmail.js
+++ b/src/content/js/plugins/gmail.js
@@ -165,7 +165,7 @@ App.plugin('gmail', (function () {
         }
 
         if (callback) {
-            callback(null, {});
+            callback(null, params);
         }
     };
 

--- a/src/content/js/plugins/gmail.js
+++ b/src/content/js/plugins/gmail.js
@@ -123,17 +123,27 @@ App.plugin('gmail', (function () {
 
     };
 
-    var setTitle = function (params, callback) {
+    var setField = function (params, callback) {
         getData(params, function (_, vars) {
-            var parsedSubject = Handlebars.compile(params.quicktext.subject)(PrepareVars(vars));
+            var parsedContent = Handlebars.compile(params.value)(PrepareVars(vars));
+            var $parent = $(params.element).closest('table.aoP')
 
-            var $subjectField = $(params.element).closest('table.aoP').find('input[name=subjectbox]');
-            $subjectField.val(parsedSubject);
+            if (params.field === 'subject') {
+                var $subjectField = $parent.find('input[name=subjectbox]');
+                $subjectField.val(parsedContent);
+            }
 
-            var response = {};
+            if (params.field === 'to') {
+                var $toField = $parent.find('textarea[name=to]');
+                $toField.val(parsedContent);
+
+                // a little jumpy,
+                // but the only to way to force showing the new value.
+                $parent.find('.aoD.hl').trigger('focus');
+            }
 
             if (callback) {
-                callback(null, response);
+                callback(null, {});
             }
         });
     };
@@ -291,7 +301,7 @@ App.plugin('gmail', (function () {
         init: init,
         getData: getData,
         setAttachment: setAttachmentNode,
-        setTitle: setTitle
+        setField: setField
     }
 
 })());

--- a/src/content/js/plugins/gmail.js
+++ b/src/content/js/plugins/gmail.js
@@ -123,45 +123,52 @@ App.plugin('gmail', (function () {
 
     };
 
-    var setField = function (params, callback) {
-        getData(params, function (_, vars) {
-            var parsedValue = Handlebars.compile(params.value)(PrepareVars(vars));
-            var $parent = $(params.element).closest('table.aoP')
+    var before = function (params, callback) {
+        var $parent = $(params.element).closest('table.aoP')
 
-            if (params.field === 'subject') {
-                $parent.find('input[name=subjectbox]').val(parsedValue);
-            }
+        if (params.quicktext.subject) {
+            var parsedSubject = Handlebars.compile(params.quicktext.subject)(PrepareVars(params.data));
+            $parent.find('input[name=subjectbox]').val(parsedSubject);
+        }
 
-            if ([ 'to', 'cc', 'bcc' ].indexOf(params.field) !== -1) {
-                // click the receipients row.
-                // a little jumpy,
-                // but the only to way to show the new value.
-                $parent.find('.aoD.hl').trigger('focus');
-            }
+        if (params.quicktext.to ||
+            params.quicktext.cc ||
+            params.quicktext.bcc
+        ) {
+            // click the receipients row.
+            // a little jumpy,
+            // but the only to way to show the new value.
+            $parent.find('.aoD.hl').trigger('focus');
+        }
 
-            if (params.field === 'to') {
-                $parent.find('textarea[name=to]').val(parsedValue);
-            }
+        if (params.quicktext.to) {
+            var parsedTo = Handlebars.compile(params.quicktext.to)(PrepareVars(params.data));
+            $parent.find('textarea[name=to]').val(parsedTo);
+        }
 
-            if (params.field === 'cc') {
-                // click the cc button
-                $parent.find('.aB.gQ.pE').trigger('click');
+        if (params.quicktext.cc) {
+            var parsedCc = Handlebars.compile(params.quicktext.cc)(PrepareVars(params.data));
 
-                $parent.find('textarea[name=cc]').val(parsedValue);
-            }
+            // click the cc button
+            $parent.find('.aB.gQ.pE').trigger('click');
 
-            if (params.field === 'bcc') {
-                // click the bcc button
-                $parent.find('.aB.gQ.pB').trigger('click');
+            $parent.find('textarea[name=cc]').val(parsedCc);
+        }
 
-                $parent.find('textarea[name=bcc]').val(parsedValue);
-            }
+        if (params.quicktext.bcc) {
+            var parsedBcc = Handlebars.compile(params.quicktext.bcc)(PrepareVars(params.data));
 
-            if (callback) {
-                callback(null, {});
-            }
-        });
+            // click the bcc button
+            $parent.find('.aB.gQ.pB').trigger('click');
+
+            $parent.find('textarea[name=bcc]').val(parsedBcc);
+        }
+
+        if (callback) {
+            callback(null, {});
+        }
     };
+
     //insert attachment node on gmail editor.
     var setAttachmentNode = function (attachment, range) {
         if (!attachment) {
@@ -316,7 +323,7 @@ App.plugin('gmail', (function () {
         init: init,
         getData: getData,
         setAttachment: setAttachmentNode,
-        setField: setField
+        before: before
     }
 
 })());

--- a/src/content/js/plugins/linkedin.js
+++ b/src/content/js/plugins/linkedin.js
@@ -86,17 +86,15 @@ App.plugin('linkedin', (function() {
 
     };
 
-    var setTitle = function(params, callback) {
-
-        var response = {};
-
-        var $subjectField = $('#subject-msgForm', window.parent.document);
-        $subjectField.val(params.quicktext.subject);
-
-        if(callback) {
-            callback(null, response);
+    var before = function(params, callback) {
+        if(params.quicktext.subject) {
+            var $subjectField = $('#subject-msgForm', window.parent.document);
+            $subjectField.val(params.quicktext.subject);
         }
 
+        if(callback) {
+            callback(null, params);
+        }
     };
 
     var init = function(params, callback) {
@@ -122,7 +120,7 @@ App.plugin('linkedin', (function() {
     return {
         init: init,
         getData: getData,
-        setTitle: setTitle
+        before: before
     }
 
 })());

--- a/src/content/js/plugins/outlook.js
+++ b/src/content/js/plugins/outlook.js
@@ -91,16 +91,32 @@ App.plugin('outlook', (function() {
 
     var setField = function(params, callback) {
         getData(params, function (_, vars) {
+            var $parent = $(params.element).closest('._mcp_61');
             var parsedValue = Handlebars.compile(params.value)(PrepareVars(vars));
 
             if (params.field === 'subject') {
-                var $subjectField = $('input[aria-labelledby="MailCompose.SubjectWellLabel"]', window.parent.document);
+                var $subjectField = $('input[aria-labelledby="MailCompose.SubjectWellLabel"]', $parent);
 
                 $subjectField.val(parsedValue);
             }
 
-            if (params.field === 'to') {
+            var $extraFields = $('._fp_C', $parent)
+            var $btns = $('._mcp_e1', $parent)
 
+            if (params.field === 'to') {
+                $extraFields.eq(0).val(parsedValue);
+            }
+
+            if (params.field === 'cc') {
+                // click the cc button
+                $btns.eq(0).trigger('click');
+                $extraFields.eq(1).val(parsedValue);
+            }
+
+            if (params.field === 'bcc') {
+                // click the bcc button
+                $btns.eq(1).trigger('click');
+                $extraFields.eq(2).val(parsedValue);
             }
 
             if(callback) {

--- a/src/content/js/plugins/outlook.js
+++ b/src/content/js/plugins/outlook.js
@@ -89,48 +89,6 @@ App.plugin('outlook', (function() {
 
     };
 
-    var setField = function(params, callback) {
-        getData(params, function (_, vars) {
-            var $parent = $(params.element).closest('._mcp_61');
-            var parsedValue = Handlebars.compile(params.value)(PrepareVars(vars));
-
-            if (params.field === 'subject') {
-                var $subjectField = $('input[aria-labelledby="MailCompose.SubjectWellLabel"]', $parent);
-
-                $subjectField.val(parsedValue);
-            }
-
-            if ([ 'to', 'cc', 'bcc' ].indexOf(params.field) !== -1) {
-                // click expand button, for reply.
-                $('button._mcp_D2', $parent).trigger('click')
-            }
-
-            var $extraFields = $('._fp_C', $parent)
-            var $btns = $('._mcp_e1', $parent)
-
-            if (params.field === 'to') {
-                $extraFields.eq(0).val(parsedValue);
-            }
-
-            // TODO does not work in Reply
-            if (params.field === 'cc') {
-                // click the cc button
-                $btns.eq(0).trigger('click');
-                $extraFields.eq(1).val(parsedValue);
-            }
-
-            if (params.field === 'bcc') {
-                // click the bcc button
-                $btns.eq(1).trigger('click');
-                $extraFields.eq(2).val(parsedValue);
-            }
-
-            if(callback) {
-                callback(null, {});
-            }
-        });
-    };
-
     var before = function (params, callback) {
         // don't do anything if we don't have any extra fields
         if (!params.quicktext.subject &&

--- a/src/content/js/plugins/outlook.js
+++ b/src/content/js/plugins/outlook.js
@@ -107,6 +107,7 @@ App.plugin('outlook', (function() {
                 $extraFields.eq(0).val(parsedValue);
             }
 
+            // TODO does not work in Reply
             if (params.field === 'cc') {
                 // click the cc button
                 $btns.eq(0).trigger('click');

--- a/src/content/js/plugins/outlook.js
+++ b/src/content/js/plugins/outlook.js
@@ -89,22 +89,29 @@ App.plugin('outlook', (function() {
 
     };
 
-    var setTitle = function(params, callback) {
+    var setField = function(params, callback) {
+        getData(params, function (_, vars) {
+            var parsedValue = Handlebars.compile(params.value)(PrepareVars(vars));
 
-        var response = {};
+            if (params.field === 'subject') {
+                var $subjectField = $('input[aria-labelledby="MailCompose.SubjectWellLabel"]', window.parent.document);
 
-        var $subjectField = $('input[name=fSubject]', window.parent.document);
-        $subjectField.val(params.quicktext.subject);
+                $subjectField.val(parsedValue);
+            }
 
-        if(callback) {
-            callback(null, response);
-        }
+            if (params.field === 'to') {
 
+            }
+
+            if(callback) {
+                callback(null, {});
+            }
+        });
     };
 
     var init = function(params, callback) {
 
-        var outlookUrl = '.mail.live.com/';
+        var outlookUrl = 'outlook.live.com/';
 
         var activateExtension = false;
 
@@ -125,7 +132,7 @@ App.plugin('outlook', (function() {
     return {
         init: init,
         getData: getData,
-        setTitle: setTitle
+        setField: setField
     }
 
 })());

--- a/src/content/js/plugins/uservoice.js
+++ b/src/content/js/plugins/uservoice.js
@@ -69,17 +69,16 @@ App.plugin('uservoice', (function () {
 
     };
 
-    var setTitle = function (params, callback) {
-
-        var response = {};
-
-        var $subjectField = $('input[name=subjectbox]');
-        $subjectField.val(params.quicktext.subject);
-
-        if (callback) {
-            callback(null, response);
+    var before = function (params, callback) {
+        if (params.quicktext.subject) {
+            var parsedSubject = Handlebars.compile(params.quicktext.subject)(PrepareVars(params.data));
+            var $subjectField = $('input[name=subjectbox]');
+            $subjectField.val(parsedSubject);
         }
 
+        if (callback) {
+            callback(null, params);
+        }
     };
 
     var init = function (params, callback) {
@@ -122,7 +121,7 @@ App.plugin('uservoice', (function () {
     return {
         init: init,
         getData: getData,
-        setTitle: setTitle
+        before: before
     }
 
 })());

--- a/src/content/js/plugins/yahoo.js
+++ b/src/content/js/plugins/yahoo.js
@@ -126,18 +126,6 @@ App.plugin('yahoo', (function() {
         }
     };
 
-    var setTitle = function(params, callback) {
-
-        var response = {};
-
-
-
-        if(callback) {
-            callback(null, response);
-        }
-
-    };
-
     var init = function(params, callback) {
 
         var yahooUrl = '.mail.yahoo.com/';

--- a/src/content/js/plugins/yahoo.js
+++ b/src/content/js/plugins/yahoo.js
@@ -81,12 +81,56 @@ App.plugin('yahoo', (function() {
 
     };
 
+    var before = function (params, callback) {
+        var $parent = $(params.element).closest('div.compose')
+
+        if (params.quicktext.subject) {
+            var parsedSubject = Handlebars.compile(params.quicktext.subject)(PrepareVars(params.data));
+            var $subjectField = $('#subject-field', $parent);
+            $subjectField.val(parsedSubject);
+        }
+
+        if (params.quicktext.to) {
+            var parsedTo = Handlebars.compile(params.quicktext.to)(PrepareVars(params.data));
+            var $toField = $('#to-field', $parent);
+            $toField.val(parsedTo);
+
+            $toField.get(0).dispatchEvent(new Event('blur'));
+        }
+
+        if (params.quicktext.cc ||
+            params.quicktext.bcc) {
+            // click show cc/bcc button
+            var $btn = $('#cc_show_btn_in_to', $parent)
+            $btn.get(0).click()
+        }
+
+        if (params.quicktext.cc) {
+            var parsedCc = Handlebars.compile(params.quicktext.cc)(PrepareVars(params.data));
+            var $ccField = $('#cc-field', $parent);
+            $ccField.val(parsedCc);
+
+            $ccField.get(0).dispatchEvent(new Event('blur'));
+        }
+
+        if (params.quicktext.bcc) {
+            var parsedBcc = Handlebars.compile(params.quicktext.bcc)(PrepareVars(params.data));
+            var $bccField = $('#bcc-field', $parent);
+            $bccField.val(parsedBcc);
+
+            $bccField.get(0).dispatchEvent(new Event('blur'));
+        }
+
+        if (callback) {
+            callback(null, params);
+        }
+    };
+
     var setTitle = function(params, callback) {
 
         var response = {};
 
-        var $subjectField = $('#subject-field');
-        $subjectField.val(params.quicktext.subject);
+
 
         if(callback) {
             callback(null, response);
@@ -117,7 +161,7 @@ App.plugin('yahoo', (function() {
     return {
         init: init,
         getData: getData,
-        setTitle: setTitle
+        before: before
     }
 
 })());

--- a/src/content/js/plugins/zendesk-dropdown.js
+++ b/src/content/js/plugins/zendesk-dropdown.js
@@ -505,14 +505,9 @@ App.plugin('zendesk', (function () {
         });
     };
 
-    var setTitle = function (params, callback) {
-
-    };
-
     return {
         init: init,
-        getData: getData,
-        setTitle: setTitle
+        getData: getData
     };
 
 })());

--- a/src/content/js/plugins/zendesk.js
+++ b/src/content/js/plugins/zendesk.js
@@ -255,14 +255,9 @@ App.plugin('zendesk', (function () {
         }
     };
 
-    var setTitle = function (params, callback) {
-
-    };
-
     return {
         init: init,
-        getData: getData,
-        setTitle: setTitle
+        getData: getData
     };
 
 })());

--- a/src/pages/includes/form.html
+++ b/src/pages/includes/form.html
@@ -140,13 +140,6 @@
                         </div>
                     </div>
 
-
-                    <div class="form-group">
-                        <button type="button" class="btn btn-link" ng-show="templateForm.extraFields" ng-click="templateForm.showExtraFields()">
-                            Show more fields
-                        </button>
-                    </div>
-
                     <div class="form-group" data-toggle="tooltip" data-placement="bottom"
                          title="The e-mail subject will be replaced with this field. Only when this template is used." ng-show="templateForm.extraFieldContent(templateForm.selectedTemplate.subject)">
                         <label for="qt-subject">Subject <span class="text-muted">(Optional)</span></label>
@@ -160,6 +153,11 @@
                                placeholder=""/>
                     </div>
 
+                    <div class="form-group">
+                        <button type="button" class="btn btn-link" ng-show="templateForm.extraFields" ng-click="templateForm.showExtraFields()">
+                            Show more fields
+                        </button>
+                    </div>
 
                     <div class="form-group">
                         <label for="qt-tags">

--- a/src/pages/includes/form.html
+++ b/src/pages/includes/form.html
@@ -44,12 +44,6 @@
                         </div>
                     </div>
 
-                    <div class="form-group" data-toggle="tooltip" data-placement="bottom"
-                         title="The e-mail subject will be replaced with this field. Only when this template is used.">
-                        <label for="qt-subject">Subject <span class="text-muted">(Optional)</span></label>
-                        <input type="text" class="form-control" id="qt-subject" ng-model="templateForm.selectedTemplate.subject"
-                               placeholder=""/>
-                    </div>
                     <div class="form-group">
                         <label class="body-label">Template Content</label>
 
@@ -145,6 +139,28 @@
                             <i class='fa fa-paperclip'/><a target='_blank' class='attachment' href='{{attachment.url}}'>{{attachment.name}}</a><i class='fa fa-close' ng-click="templateForm.removeAttachment($index)"/>
                         </div>
                     </div>
+
+
+                    <div class="form-group">
+                        <button type="button" class="btn btn-link" ng-show="templateForm.extraFields" ng-click="templateForm.showExtraFields()">
+                            Show more fields
+                        </button>
+                    </div>
+
+                    <div class="form-group" data-toggle="tooltip" data-placement="bottom"
+                         title="The e-mail subject will be replaced with this field. Only when this template is used." ng-show="templateForm.extraFieldContent(templateForm.selectedTemplate.subject)">
+                        <label for="qt-subject">Subject <span class="text-muted">(Optional)</span></label>
+                        <input type="text" class="form-control" id="qt-subject" ng-model="templateForm.selectedTemplate.subject"
+                               placeholder=""/>
+                    </div>
+
+                    <div class="form-group" ng-show="templateForm.extraFieldContent(templateForm.selectedTemplate.to)">
+                        <label for="qt-to">To <span class="text-muted">(Optional)</span></label>
+                        <input type="text" class="form-control" id="qt-to" ng-model="templateForm.selectedTemplate.to"
+                               placeholder=""/>
+                    </div>
+
+
                     <div class="form-group">
                         <label for="qt-tags">
                             Tags

--- a/src/pages/includes/form.html
+++ b/src/pages/includes/form.html
@@ -147,10 +147,24 @@
                                placeholder=""/>
                     </div>
 
-                    <div class="form-group" ng-show="templateForm.extraFieldContent(templateForm.selectedTemplate.to)">
-                        <label for="qt-to">To <span class="text-muted">(Optional)</span></label>
-                        <input type="text" class="form-control" id="qt-to" ng-model="templateForm.selectedTemplate.to"
-                               placeholder=""/>
+                    <div class="form-group-grid">
+                        <div class="form-group" ng-show="templateForm.extraFieldContent(templateForm.selectedTemplate.to)">
+                            <label for="qt-to">To <span class="text-muted">(Optional)</span></label>
+                            <input type="text" class="form-control" id="qt-to" ng-model="templateForm.selectedTemplate.to"
+                                placeholder=""/>
+                        </div>
+
+                        <div class="form-group" ng-show="templateForm.extraFieldContent(templateForm.selectedTemplate.cc)">
+                            <label for="qt-cc">CC <span class="text-muted">(Optional)</span></label>
+                            <input type="text" class="form-control" id="qt-cc" ng-model="templateForm.selectedTemplate.cc"
+                                placeholder=""/>
+                        </div>
+
+                        <div class="form-group" ng-show="templateForm.extraFieldContent(templateForm.selectedTemplate.bcc)">
+                            <label for="qt-bcc">BCC <span class="text-muted">(Optional)</span></label>
+                            <input type="text" class="form-control" id="qt-bcc" ng-model="templateForm.selectedTemplate.bcc"
+                                placeholder=""/>
+                        </div>
                     </div>
 
                     <div class="form-group">


### PR DESCRIPTION
#### Status: :white_check_mark: 
#### Connects to #169 

#### Plugin status:
- :green_heart: Gmail
- :green_heart: Outlook
- :green_heart: Fastmail
- :green_heart: Yahoo

#### Unsupported plugins:
- Facebook
- Desk
- LinkedIn
- UserVoice
- Zendesk Dropdown
- Zendesk

#### Features:
- Support for To, CC and BCC fields
- <s>Replaced `setTitle` method in plugins with `setField`. It will be called with
`{ field: 'subject', value: 'quicktext title', element: $textarea }` for each field in the quicktext (subject, to, cc, bcc).</s>
- New `before` and `after` optional methods for plugins. They run before and after the quicktext is inserted. They get the same `params` as the `getData` method, and can modify them then pass them on in the callback. 
- In the future we'll probably be able to merge `getData` into `before`.

#### Testing:
- `git checkout show-more-fields`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gorgias/gorgias-chrome/219)
<!-- Reviewable:end -->
