### PR TITLE
Different style for the *use* keys, in the install tutorial

### DIFF
--- a/src/background/js/utils/demo.js
+++ b/src/background/js/utils/demo.js
@@ -27,9 +27,9 @@ var gorgiasDemo = (function () {
             body: 'It was nice talking to you!'
         },*/
         {
-            shortcut: 'use',
+            shortcut: 'glad',
             title: 'Glad to use Gorgias',
-            body: "I'm glad to use Gorgias for the first time. Keyboard completion is great!"
+            body: "I'm glad to use Gorgias for the first time. Keyboard completion is great!<br /><br />"
         },
         {
             shortcut: 'kr',
@@ -633,7 +633,7 @@ var gorgiasDemo = (function () {
 
             }
 
-            if (params.quicktext.shortcut === 'use') {
+            if (params.quicktext.shortcut === 'glad') {
                 setTimeout(function () {
                     $('.gorgias-demo-hint>*').addClass('hidden');
                     $('.gorgias-demo-hint .search').removeClass('hidden').addClass('fadein');

--- a/src/pages/views/installed.html
+++ b/src/pages/views/installed.html
@@ -21,7 +21,7 @@
             </li>
             <li class="gdemo-item">
                 <span class="gdemo-title">How to use Gorgias</span>
-                <span class="gdemo-shortcut">use</span>
+                <span class="gdemo-shortcut">glad</span>
                 <span class="gdemo-body">It was nice talking to you.</span>
             </li>
             <li class="gdemo-item">
@@ -48,7 +48,7 @@
             <p class="gorgias-demo-hint text-center">
                 <span class="h">Type <span class="keyboard-key">h</span> and press <span
                     class="keyboard-key">Tab ↹</span></span>
-                <span class="use hidden">Great! Now type <span class="keyboard-key">use</span> and press <span
+                <span class="use hidden">Great! Now type the word <span class="keyboard-key">glad</span> and press <span
                     class="keyboard-key">Tab ↹</span></span>
                 <span class="search hidden">You can also search for templates. <span class="g-search-arrow"></span></span>
                 <span class="select hidden">Select one that fits. Click on any template.</span>


### PR DESCRIPTION
#### Status: :white_check_mark: 
#### Connects to #208 

#### Features:
* Use a different text style for the `use` keys, in the install tutorial, to not be confused as a keyboard shortcut.

#### Testing:
- `git checkout key-use`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gorgias/gorgias-chrome/222)
<!-- Reviewable:end -->
