### PR TITLE
Google Inbox support

### DIFF
--- a/src/background/js/chrome-config.js
+++ b/src/background/js/chrome-config.js
@@ -6,6 +6,7 @@ if (chrome.runtime) {
     // for tabs.query auto-reload
     var urlMatchPatterns = [
         '*://mail.google.com/*',
+        '*://inbox.google.com/*',
         '*://*.mail.yahoo.com/*',
         '*://*.mail.live.com/*',
         '*://outlook.live.com/*',

--- a/src/content/js/plugins/google-inbox.js
+++ b/src/content/js/plugins/google-inbox.js
@@ -75,10 +75,10 @@ App.plugin('google-inbox', (function () {
     // get all required data from the dom
     var getData = function (params, callback) {
         var vars = {
-            from: {},
-            to: {},
-            cc: {},
-            bcc: {},
+            from: [],
+            to: [],
+            cc: [],
+            bcc: [],
             subject: ''
         }
 
@@ -86,9 +86,11 @@ App.plugin('google-inbox', (function () {
         var $accountContainer = jQuery('.gb_lb.gb_ga');
 
         // from
-        vars.from.name = $accountContainer.find('.gb_ub').text();
-        jQuery.extend(vars.from, splitFullName(vars.from.name));
-        vars.from.email = $accountContainer.find('.gb_vb').text();
+        var name = $accountContainer.find('.gb_ub').text()
+        vars.from.push(jQuery.extend({
+            name: name,
+            email: $accountContainer.find('.gb_vb').text()
+        }, splitFullName(name)));
 
         var nodes = getNodes(params.element);
         ['to', 'cc', 'bcc'].forEach(function (receiver) {
@@ -115,12 +117,10 @@ App.plugin('google-inbox', (function () {
                 name = $field.attr('aria-label')
             }
 
-            vars[receiver] = {
+            vars[receiver].push(jQuery.extend({
                 name: name,
                 email: $field.attr('email')
-            }
-
-            jQuery.extend(vars[receiver], splitFullName(vars[receiver].name))
+            }, splitFullName(name)));
         })
 
         // subject

--- a/src/content/js/plugins/google-inbox.js
+++ b/src/content/js/plugins/google-inbox.js
@@ -75,7 +75,7 @@ App.plugin('google-inbox', (function () {
     // get all required data from the dom
     var getData = function (params, callback) {
         var vars = {
-            from: [],
+            from: {},
             to: [],
             cc: [],
             bcc: [],
@@ -87,10 +87,10 @@ App.plugin('google-inbox', (function () {
 
         // from
         var name = $accountContainer.find('.gb_ub').text()
-        vars.from.push(jQuery.extend({
+        vars.from = jQuery.extend({
             name: name,
             email: $accountContainer.find('.gb_vb').text()
-        }, splitFullName(name)));
+        }, splitFullName(name));
 
         var nodes = getNodes(params.element);
         ['to', 'cc', 'bcc'].forEach(function (receiver) {

--- a/src/content/js/plugins/google-inbox.js
+++ b/src/content/js/plugins/google-inbox.js
@@ -1,0 +1,147 @@
+/* Google Inbox plugin
+ */
+
+App.plugin('google-inbox', (function () {
+    // split full name by last space.
+    // TODO share this between plugins.
+    var splitFullName = function (fullname) {
+        fullname = fullname || ''
+
+        var lastSpaceIndex = fullname.lastIndexOf(' ')
+        if (lastSpaceIndex < 1) {
+            lastSpaceIndex = fullname.length
+        }
+
+        return {
+            first_name: fullname.substr(0, lastSpaceIndex),
+            last_name: fullname.substr(lastSpaceIndex + 1)
+        }
+    }
+
+    var getNodes = function (element) {
+        var nodes = {}
+
+        // .n7 for message popup
+        // .nG for inline reply
+        // only one is rendered at a time.
+        nodes.container = jQuery(element).closest('.n7, .nG')
+
+        // TODO detect if in message popup or inline.
+        // currently only works message popup.
+        // TODO inline reply
+        // var $meta = nodes.container.prev('.kX')
+
+        // to, cc, bcc
+        var receivers = [
+            { type: 'to', className: '.Fv' },
+            { type: 'cc', className: '.fD' },
+            { type: 'bcc', className: '.fx' }
+        ];
+
+        receivers.forEach(function (receiver) {
+            var $fieldContainer = nodes.container.siblings(receiver.className);
+            // when a receiver is deleted, the node is still there but display:none.
+            nodes[receiver.type] = $fieldContainer.find('[email]:visible').eq(0);
+        })
+
+        // subject
+        nodes.subject = nodes.container.siblings('.iO').find('input');
+
+        return nodes
+    };
+
+    // get all required data from the dom
+    var getData = function (params, callback) {
+        var vars = {
+            from: {},
+            to: {},
+            cc: {},
+            bcc: {},
+            subject: ''
+        }
+
+        // account information
+        var $accountContainer = jQuery('.gb_lb.gb_ga');
+
+        // from
+        vars.from.name = $accountContainer.find('.gb_ub').text();
+        jQuery.extend(vars.from, splitFullName(vars.from.name));
+        vars.from.email = $accountContainer.find('.gb_vb').text();
+
+        // editor container
+        var nodes = getNodes(params.element);
+        [ 'to', 'cc', 'bcc' ].forEach(function (receiver) {
+            var $field = nodes[receiver]
+            if (!$field.length) {
+                return;
+            }
+
+            vars[receiver] = {
+                name: $field.attr('aria-label'),
+                email: $field.attr('email')
+            }
+
+            jQuery.extend(vars[receiver], splitFullName(vars[receiver].name))
+        })
+
+        // subject
+        vars.subject = nodes.subject.val();
+
+        if (callback) {
+            callback(null, vars);
+        }
+    };
+
+    var before = function (params, callback) {
+        var nodes = getNodes(params.element)
+
+        if (params.quicktext.subject) {
+            var parsedSubject = Handlebars.compile(params.quicktext.subject)(PrepareVars(params.data));
+            var newSubject = nodes.subject.val() + parsedSubject;
+            nodes.subject.val(newSubject);
+        }
+
+        if (params.quicktext.to) {
+            var parsedTo = Handlebars.compile(params.quicktext.to)(PrepareVars(params.data));
+            // TODO send toContainer from nodes,
+            // to get input here, and [email] in getData.
+            nodes.to.val(parsedTo);
+        }
+
+        if (params.quicktext.cc ||
+            params.quicktext.bcc
+        ) {
+            // click the extra receivers buttons,
+            // if fields are hidden.
+            if (!nodes.cc.is(':visible')) {
+                // TODO does not work
+                nodes.container.find('.p2.IB').trigger('click')
+            }
+        }
+
+        if (callback) {
+            callback(null, params);
+        }
+    };
+
+    var init = function (params, callback) {
+        var ginboxUrl = '//inbox.google.com/';
+
+        var activateExtension = false;
+
+        // trigger the extension based on url
+        if (window.location.href.indexOf(ginboxUrl) !== -1) {
+            activateExtension = true;
+        }
+
+        if (callback) {
+            callback(null, activateExtension);
+        }
+    };
+
+    return {
+        init: init,
+        getData: getData,
+        before: before
+    }
+})());

--- a/src/content/js/plugins/google-inbox.js
+++ b/src/content/js/plugins/google-inbox.js
@@ -90,7 +90,6 @@ App.plugin('google-inbox', (function () {
         jQuery.extend(vars.from, splitFullName(vars.from.name));
         vars.from.email = $accountContainer.find('.gb_vb').text();
 
-        // editor container
         var nodes = getNodes(params.element);
         ['to', 'cc', 'bcc'].forEach(function (receiver) {
             if (!nodes[receiver]) {
@@ -102,7 +101,7 @@ App.plugin('google-inbox', (function () {
 
             // inline sends the [email] node,
             // popup sends the [email] node container.
-            if ($field.attr('email')) {
+            if (nodes.mode === 'inline') {
                 // inline.
                 name = $field.text()
             } else {
@@ -147,8 +146,8 @@ App.plugin('google-inbox', (function () {
             // click the pop-out button
             nodes.container.closest('.bc').find('[jsaction*="quick_compose_popout_mole"]').trigger('click')
 
-            // the focus moves to the popup,
-            // so update the element and focusNode reference.
+            // focus moves to the popup,
+            // so update the element and focusNode refs.
             // sometimes the popup does not open fast enough,
             // and the activeElement is still in inline cursor,
             // so we need the timeout trick.
@@ -172,7 +171,7 @@ App.plugin('google-inbox', (function () {
         }
     }
 
-    // we can't use after() here,
+    // can't use after(),
     // because it messes with the focus.
     var fillFields = function (params) {
         var nodes = getNodes(params.element);
@@ -198,9 +197,7 @@ App.plugin('google-inbox', (function () {
             $toField.get(0).dispatchEvent(blurEvent);
         }
 
-        if (params.quicktext.cc ||
-            params.quicktext.bcc
-        ) {
+        if (params.quicktext.cc || params.quicktext.bcc) {
             // click the extra receivers buttons,
             // if fields are hidden.
             if (!nodes.cc.is(':visible')) {


### PR DESCRIPTION
#### Status: :white_check_mark:
#### Connects to #109

#### Features:
- Support for Google Inbox:
- Works in message popup and in inline reply.
- If a template has to populate one of the other fields (subject/to/cc/bcc) while in inline-reply, it opens the message popup.

#### Testing:
- `git checkout ghinda--googleinbox-suport`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gorgias/gorgias-chrome/226)
<!-- Reviewable:end -->
