### PR TITLE
Fix issues with filtering the template list

### DIFF
--- a/src/background/js/controllers/list.js
+++ b/src/background/js/controllers/list.js
@@ -429,4 +429,17 @@ gApp.controller('ListCtrl',
         $scope.loadMore = function () {
             $scope.limitTemplates += 42;
         };
+
+        $scope.filterTemplates = function () {
+            // fuzzy serach
+            var matchedTemplates = $filter('fuzzy')($scope.templates, $scope.searchText, $scope.searchOptions)
+
+            // tags
+            matchedTemplates = $filter('tagFilter')(matchedTemplates, $scope.filterTags)
+
+            // sharing filter
+            matchedTemplates = $filter('sharingFilter')(matchedTemplates, $scope.properties.list)
+
+            return matchedTemplates
+        };
     });

--- a/src/pages/views/list.html
+++ b/src/pages/views/list.html
@@ -44,10 +44,9 @@
         </p>
     </div>
 
-    <div class="list-group quicktexts-list" ng-show="templates.length">
+    <div class="list-group quicktexts-list" ng-show="filteredTemplates.length">
         <div class="list-group-item"
-             ng-repeat="template in templates | fuzzy:searchText:searchOptions | limitTo:limitTemplates | tagFilter:filterTags | sharingFilter:properties.list as filteredTemplates">
-
+             ng-repeat="template in filterTemplates() | limitTo:limitTemplates as filteredTemplates">
             <div class="checkbox-wrapper">
                 <input type="checkbox" ng-change="checkHasSelected()" ng-model="selectedQuickTexts[template.id]">
             </div>
@@ -95,7 +94,7 @@
             </div>
         </div>
     </div>
-    <div class="row load-more text-center" ng-show="templates.length > limitTemplates">
+    <div class="row load-more text-center" ng-show="filterTemplates().length > limitTemplates">
         <button ng-click="loadMore()" class="btn btn-default">Load more templates</button>
     </div>
 </div>


### PR DESCRIPTION
#### Status: :white_check_mark:
#### Connects to #230 

#### Fixs:
Fixes bugs with wrongly filtering the template list and showing the Load More button:
- Templates were not filtered correctly because the `limitTo` filter was applied on the full template list, *before* filtering by other criteria (search, tags, etc.).
- This was causing only the first 42 templates (on first load, before pressing the Load More button) to be filtered by search, tags, etc.
- The bug is only visible when you have more than 42 templates.

#### Testing:
- `git checkout ghinda--bug-tag-filtering`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gorgias/gorgias-chrome/231)
<!-- Reviewable:end -->
