### PR TITLE
Google Inbox hotfix for inserting templates when editor is empty

### DIFF
--- a/src/content/css/content.styl
+++ b/src/content/css/content.styl
@@ -222,7 +222,7 @@ $padding = 8px;
     box-shadow: 0 1px 0 rgba(0, 0, 0, 0.08), inset 0 1px 2px rgba(255, 255, 255, 0.75);
     color: #444;
     text-shadow: 0 1px 0 #F0F0F0;
-    transition: all .1s ease-out;
+    transition: opacity .1s ease-out;
 
     &:hover {
         opacity: 1 !important;

--- a/src/content/js/autocomplete.js
+++ b/src/content/js/autocomplete.js
@@ -231,9 +231,18 @@ App.autocomplete.replaceWith = function (params) {
                     if (focusNode.childNodes.length > 0) {
                         focusNode = focusNode.childNodes[selection.focusOffset]; // select a text node
                     } else {
-                        // create an empty text node and attach it before the node
+                        // create an empty text node
                         var tnode = doc.createTextNode('');
-                        focusNode.parentNode.insertBefore(tnode, focusNode);
+
+                        // if the focusNode is the same as the element
+                        if (focusNode === params.element) {
+                            // insert it in the node
+                            focusNode.appendChild(tnode);
+                        } else {
+                            // or attach it before the node
+                            focusNode.parentNode.insertBefore(tnode, focusNode);
+                        }
+
                         focusNode = tnode;
                     }
                 }

--- a/src/content/js/plugins/google-inbox.js
+++ b/src/content/js/plugins/google-inbox.js
@@ -216,6 +216,17 @@ App.plugin('google-inbox', (function () {
         });
     };
 
+    var after = function (params, callback) {
+        // inserting a template while the placeholder text is still visible,
+        // needs a manual event trigger.
+        var inputEvent = new Event('input');
+        params.element.dispatchEvent(inputEvent);
+
+        if (callback) {
+            callback(null, params);
+        }
+    };
+
     var init = function (params, callback) {
         var ginboxUrl = '//inbox.google.com/';
 
@@ -234,6 +245,7 @@ App.plugin('google-inbox', (function () {
     return {
         init: init,
         getData: getData,
-        before: before
+        before: before,
+        after: after
     }
 })());

--- a/src/content/js/plugins/google-inbox.js
+++ b/src/content/js/plugins/google-inbox.js
@@ -207,7 +207,7 @@ App.plugin('google-inbox', (function () {
 
         ['cc', 'bcc'].forEach(function (type) {
             if (params.quicktext[type]) {
-                var parsed = Handlebars.compile(params.quicktext.cc)(PrepareVars(params.data));
+                var parsed = Handlebars.compile(params.quicktext[type])(PrepareVars(params.data));
                 var $field = nodes[type].find('input');
                 $field.val(parsed);
 

--- a/src/content/js/plugins/google-inbox.js
+++ b/src/content/js/plugins/google-inbox.js
@@ -82,14 +82,27 @@ App.plugin('google-inbox', (function () {
             subject: ''
         }
 
-        // account information
-        var $accountContainer = jQuery('.gb_lb.gb_ga');
+        // title = Google Account: User Name (user@email.net)
+        var $signoutBtn = jQuery('[title^="Google Account: "]')
+        var btnTitle = $signoutBtn.attr('title')
+
+        var name = btnTitle.replace(/Google Account:|\r?\n|\r/g, '').trim();
+        var email = '';
+
+        var openBracket = name.lastIndexOf('(')
+        // in case of no brackets
+        if (openBracket === -1) {
+            openBracket = name.length
+        } else {
+            email = name.substr(openBracket).slice(1, -1);
+        }
+
+        name = name.substr(0, openBracket).trim();
 
         // from
-        var name = $accountContainer.find('.gb_ub').text()
         vars.from = jQuery.extend({
             name: name,
-            email: $accountContainer.find('.gb_vb').text()
+            email: email
         }, splitFullName(name));
 
         var nodes = getNodes(params.element);


### PR DESCRIPTION
#### Status: :question:
#### Connects to #109 

In Google Inbox:
* Fixes issues with inserting templates when the editor is empty:
https://github.com/gorgias/gorgias-chrome/issues/109#issuecomment-282179077
* Enable the quick-action button

#### Question:
* Should I tweak the dialog positioning to consider the element's padding?
![dialog-position](https://cloud.githubusercontent.com/assets/325171/23366411/48b878c8-fd0f-11e6-8b98-6c24618f1b7b.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gorgias/gorgias-chrome/246)
<!-- Reviewable:end -->
