### PR TITLE
Support attaching files from Team Drives

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "gorgias",
-    "version": "5.7.2",
+    "version": "5.8.0",
     "description": "Gorgias grunt package",
     "main": "Gruntfile.js",
     "scripts": {

--- a/src/background/js/services/google-drive-picker.js
+++ b/src/background/js/services/google-drive-picker.js
@@ -31,15 +31,16 @@ gApp.service('gDrivePickerService', function ($window) {
          */
         function createPicker() {
             if (pickerApiLoaded && oauthToken) {
-                var view = new google.picker.View(google.picker.ViewId.DOCS)
-                        // TODO only works for DocsView?
-//                     .setEnableTeamDrives(true)
+                var personalView = new google.picker.View(google.picker.ViewId.DOCS);
+                var teamDriveView = new google.picker.DocsView()
+                    .setEnableTeamDrives(true);
 
                 self.picker = new google.picker.PickerBuilder()
                     .setOAuthToken(oauthToken)
-                    .enableFeature('multiselectEnabled')
-                    .enableFeature('supportTeamDrives')
-                    .addView(view)
+                    .enableFeature(google.picker.Feature.MULTISELECT_ENABLED)
+                    .enableFeature(google.picker.Feature.SUPPORT_TEAM_DRIVES)
+                    .addView(personalView)
+                    .addView(teamDriveView)
                     .setCallback(self.pickerResponse)
                     .build();
 

--- a/src/background/js/services/google-drive-picker.js
+++ b/src/background/js/services/google-drive-picker.js
@@ -31,7 +31,18 @@ gApp.service('gDrivePickerService', function ($window) {
          */
         function createPicker() {
             if (pickerApiLoaded && oauthToken) {
-                self.picker = new google.picker.PickerBuilder().addView(google.picker.ViewId.DOCS).setOAuthToken(oauthToken).enableFeature('multiselectEnabled').setCallback(self.pickerResponse).build();
+                var view = new google.picker.View(google.picker.ViewId.DOCS)
+                        // TODO only works for DocsView?
+//                     .setEnableTeamDrives(true)
+
+                self.picker = new google.picker.PickerBuilder()
+                    .setOAuthToken(oauthToken)
+                    .enableFeature('multiselectEnabled')
+                    .enableFeature('supportTeamDrives')
+                    .addView(view)
+                    .setCallback(self.pickerResponse)
+                    .build();
+
                 self.picker.setVisible('true');
             }
         }

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,7 +1,7 @@
 {
     "manifest_version": 2,
     "name": "__MSG_extName__",
-    "version": "5.7.2",
+    "version": "5.8.0",
     "description": "__MSG_extDesc__",
     "short_name": "Gorgias",
     "default_locale": "en",


### PR DESCRIPTION
#### Status: ✅ 
#### Connects to #257

#### Features:
- Adds support for Team Drives in the Google Drive template attachment file picker.

![screenshot_20171110_120842](https://user-images.githubusercontent.com/325171/32654430-e6d3a334-c613-11e7-9cc1-8e09de4d5f07.png)

#### Tweaks:
- Use `google.picker.Feature.FEATURE_NAME` instead of `featureName` to have the format used in the api docs.

#### Testing:
1. Attach a new file in the template editor. Your google account must have team drives.
2. The Drive picker will have two tabs - one for your personal files and one for team drives.

- `git checkout ghinda--teamdrive`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gorgias/gorgias-chrome/260)
<!-- Reviewable:end -->
