### PR TITLE
Add cc, bcc, and to the export for signed out users

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "gorgias",
-    "version": "6.0.11",
+    "version": "6.0.12",
     "description": "Gorgias grunt package",
     "main": "index.js",
     "scripts": {

--- a/src/background/js/controllers/list.js
+++ b/src/background/js/controllers/list.js
@@ -471,12 +471,15 @@ gApp.controller('ListCtrl',
             // format the data
             itemsNotFormatted.forEach(function(item){
                 itemsFormatted.push({
-                    id: item.remote_id,
-                    title: item.title,
-                    shortcut: item.shortcut,
-                    subject: item.subject,
-                    tags: item.tags,
-                    body: item.body
+                    id: item.remote_id || '',
+                    title: item.title || '',
+                    shortcut: item.shortcut || '',
+                    subject: item.subject || '',
+                    tags: item.tags || '',
+                    cc: item.cc || '',
+                    bcc: item.bcc || '',
+                    to: item.to || '',
+                    body: item.body || '',
                 });
             });
 

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,7 +1,7 @@
 {
     "manifest_version": 2,
     "name": "__MSG_extName__",
-    "version": "6.0.11",
+    "version": "6.0.12",
     "description": "__MSG_extDesc__",
     "short_name": "Gorgias",
     "default_locale": "en",


### PR DESCRIPTION
* In the export for signed-out users, add the `cc`, `bcc` and `to` fields.
* Add empty defaults for field values.
* Fixes issues with the import removing existing cc/bcc/to fields.

### Testing

* Sign in, to sync the templates
* Sign-out after templates are synced
* Export the csv
* Sign-in as the same user
* Import the csv
* All templates should be the same, templates that previously had cc/bcc/to fields should still have them

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gorgias/gorgias-chrome/291)
<!-- Reviewable:end -->
