### PR TITLE
Remove environment.js

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,7 @@ chrome_profile
 build
 
 # It is added in git but we don't have to track this file
-src/backgrount/js/environment.js
+src/background/js/environment.js
 
 # Editor
 .idea


### PR DESCRIPTION
Fix issues with `environment.js` that were caused by a typo in `.gitignore`.

We can now remove `environment.js` from the repo, to prevent accidental commits.
The file is re-created on build by webpack.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gorgias/gorgias-chrome/292)
<!-- Reviewable:end -->
