### PR TITLE
Fix issues with LinkedIn editor

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "gorgias",
-    "version": "6.0.12",
+    "version": "6.0.13",
     "description": "Gorgias grunt package",
     "main": "index.js",
     "scripts": {

--- a/src/content/js/plugins/linkedin.js
+++ b/src/content/js/plugins/linkedin.js
@@ -105,10 +105,25 @@ App.plugin('linkedin', (function() {
 
     };
 
+    var after = function (params, callback) {
+        // needs a manual input event,
+        // to update the ember.js editor.
+        var inputEvent = new Event('input', {
+            bubbles: true,
+            cancelable: false
+        });
+        params.element.dispatchEvent(inputEvent);
+
+        if (callback) {
+            callback(null, params);
+        }
+    };
+
     return {
         init: init,
         getData: getData,
-        before: before
+        before: before,
+        after: after
     }
 
 })());

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,7 +1,7 @@
 {
     "manifest_version": 2,
     "name": "__MSG_extName__",
-    "version": "6.0.12",
+    "version": "6.0.13",
     "description": "__MSG_extDesc__",
     "short_name": "Gorgias",
     "default_locale": "en",


### PR DESCRIPTION
The new LinkedIn editor appears to be correctly rendering inserted templates, but it does not update the editor state behind the scene.
When a template is inserted and the message is sent, it only displays the template shortcut and not the actual template content.

Fixed it by triggering a manual input event.

### Reproduce issue
* Use current (`master`) version
* In any LinkedIn message box (new message, new post) type a template shortcut and press Tab
* Press Enter and the template will disappear. Only the template shortcut remains in the editor
* Also, instead of pressing Enter after inserting a template, press the Send button immediately
* Only the template shortcut will be in the posted message

### Testing
* Type a template shortcut in a LinkedIn message box (new message, new post) and press Tab
* Press Enter
* The template should still be in the editor
* Also try sending the message immediately after inserting the template, without making any changes to it. The message should contain the inserted template, not just the shortcut.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gorgias/gorgias-chrome/293)
<!-- Reviewable:end -->
