### PR TITLE
Extension updater

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "gorgias",
-    "version": "6.0.17",
+    "version": "6.0.18",
     "description": "Gorgias grunt package",
     "main": "index.js",
     "scripts": {

--- a/src/background/js/updater.js
+++ b/src/background/js/updater.js
@@ -1,0 +1,46 @@
+(function () {
+    var extensionMetaUrl = 'https://gorgias.github.io/templates-website/extension.json';
+    var manifest = chrome.runtime.getManifest();
+
+    // https://github.com/substack/semver-compare
+    function semverCompare (a, b) {
+        var pa = a.split('.');
+        var pb = b.split('.');
+        for (var i = 0; i < 3; i++) {
+            var na = Number(pa[i]);
+            var nb = Number(pb[i]);
+            if (na > nb) return 1;
+            if (nb > na) return -1;
+            if (!isNaN(na) && isNaN(nb)) return 1;
+            if (isNaN(na) && !isNaN(nb)) return -1;
+        }
+        return 0;
+    }
+
+    function checkVersion () {
+        var versionRequest = new XMLHttpRequest();
+        versionRequest.addEventListener('load', function () {
+            var extension = {
+                version: '1.0.0'
+            };
+            try {
+                extension = JSON.parse(this.responseText);
+            } catch (err) {}
+
+            if (semverCompare(extension.version, manifest.version) === 1) {
+                // force update request
+                chrome.runtime.requestUpdateCheck(function () {});
+            }
+        });
+        versionRequest.open('GET', extensionMetaUrl);
+        versionRequest.send();
+    }
+
+    chrome.runtime.onUpdateAvailable.addListener(function () {
+        chrome.runtime.reload();
+    });
+
+    if (ENV === 'production') {
+        checkVersion();
+    }
+}());

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,7 +1,7 @@
 {
     "manifest_version": 2,
     "name": "__MSG_extName__",
-    "version": "6.0.17",
+    "version": "6.0.18",
     "description": "__MSG_extDesc__",
     "short_name": "Gorgias",
     "default_locale": "en",


### PR DESCRIPTION
### Issue
- We still have users using old versions of the extension (almost a month old).
- Probably because they didn't restart Chrome, or because of a combination of the `Continue running background apps when Chrome is closed` setting (that is on by default) and using Suspend.

### Features
- Force a chrome `requestUpdateCheck` if the current extension version is lower than the latest version specified in `extension.json`.
- `extension.json` is hosted with the rest of the (upcoming) website.
- If there's an error with the `extension.json` file (404, parsing error), the updater fails silently. 
- Reload the extension when an update is available.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gorgias/gorgias-chrome/298)
<!-- Reviewable:end -->
