### PR TITLE
Fix adding attachments to templates

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "gorgias",
-    "version": "6.0.19",
+    "version": "6.0.20",
     "description": "Gorgias grunt package",
     "main": "index.js",
     "scripts": {

--- a/src/background/js/services/google-drive-picker.js
+++ b/src/background/js/services/google-drive-picker.js
@@ -9,6 +9,11 @@ gApp.service('gDrivePickerService', function ($window) {
         chrome.identity.getAuthToken({
             'interactive': true
         }, function (token) {
+            if (chrome.runtime.lastError) {
+                alert(chrome.runtime.lastError.message);
+                return
+            }
+
             oauthToken = token;
             createPicker();
         });

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -23,10 +23,10 @@
         "storage"
     ],
     "oauth2": {
-    "client_id": "255032857317-4ftb4k2p4t6dbikeo7nb9b5jmoit6lih.apps.googleusercontent.com",
-    "scopes": [
-      "https://www.googleapis.com/auth/drive"
-      ]
+        "client_id": "635874931075-3v91ir4l5vpdtf7i0asuk4q7ohr5auoc.apps.googleusercontent.com",
+        "scopes": [
+            "https://www.googleapis.com/auth/drive"
+        ]
     },
     "content_scripts": [
         {

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,7 +1,7 @@
 {
     "manifest_version": 2,
     "name": "__MSG_extName__",
-    "version": "6.0.19",
+    "version": "6.0.20",
     "description": "__MSG_extDesc__",
     "short_name": "Gorgias",
     "default_locale": "en",


### PR DESCRIPTION
- Our old OAuth `client_id` stopped working. Replace it with a new one.
- Show an error alert when `getAuthToken` throws any errors. Helps debugging issues with attachments not working - because of Chrome settings or any other issues.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gorgias/gorgias-chrome/300)
<!-- Reviewable:end -->
