### PR TITLE
Outlook custom domain support

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "gorgias",
-    "version": "6.0.21",
+    "version": "6.0.22",
     "description": "Gorgias grunt package",
     "main": "index.js",
     "scripts": {

--- a/src/content/js/plugins/outlook.js
+++ b/src/content/js/plugins/outlook.js
@@ -247,19 +247,17 @@ App.plugin('outlook', (function() {
     };
 
     var init = function(params, callback) {
-        var outlookUrl = 'outlook.live.com/';
-
         var activateExtension = false;
-
-        // trigger the extension based on url
-        if(window.location.href.indexOf(outlookUrl) !== -1) {
+        var outlookScript = '/owa.mail.js';
+        // trigger on loaded script,
+        // to support custom domains.
+        if (Array.from(document.scripts).some((script) => {
+            return (script.src || '').includes(outlookScript);
+        })) {
             activateExtension = true;
         }
 
-        // return true as response if plugin should be activated
         if(callback) {
-            // first param is the error
-            // second is the response
             callback(null, activateExtension);
         }
     };

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,7 +1,7 @@
 {
     "manifest_version": 2,
     "name": "__MSG_extName__",
-    "version": "6.0.21",
+    "version": "6.0.22",
     "description": "__MSG_extDesc__",
     "short_name": "Gorgias",
     "default_locale": "en",


### PR DESCRIPTION
- Enable support for Outlook on custom domains
- Detect Outlook by looking for the main script file, instead of the domain

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gorgias/gorgias-chrome/302)
<!-- Reviewable:end -->
