### PR TITLE
Fix issues with tags with spaces

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "gorgias",
-    "version": "6.1.0",
+    "version": "6.1.1",
     "description": "Gorgias grunt package",
     "main": "index.js",
     "scripts": {

--- a/src/background/js/controllers/includes/template_form.js
+++ b/src/background/js/controllers/includes/template_form.js
@@ -267,7 +267,10 @@ gApp.controller('TemplateFormCtrl',
                                 setTimeout(function(){ tinymce.activeEditor.setContent(self.selectedTemplate.body); }, 100);
 
                             }
-                            $.each(self.selectedTemplate.tags.split(','), function (_, tag) {
+
+                            // get tags from template service, to be cleaned-up.
+                            var tags = TemplateService.tags(self.selectedTemplate);
+                            $.each(tags, function (_, tag) {
                                 $('#qt-tags')[0].selectize.addItem($.trim(tag));
                             });
 

--- a/src/background/js/controllers/list.js
+++ b/src/background/js/controllers/list.js
@@ -486,4 +486,8 @@ gApp.controller('ListCtrl',
             });
             exporter.downloadCsv(itemsFormatted);
         };
+
+        $scope.getTags = function (template) {
+            return TemplateService.tags(template);
+        };
     });

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,7 +1,7 @@
 {
     "manifest_version": 2,
     "name": "__MSG_extName__",
-    "version": "6.1.0",
+    "version": "6.1.1",
     "description": "__MSG_extDesc__",
     "short_name": "Gorgias",
     "default_locale": "en",

--- a/src/pages/views/list.html
+++ b/src/pages/views/list.html
@@ -72,7 +72,7 @@
                                   ng-bind-html="template.body| stripHTML | truncate:100 | newlines | safe"></span>
                         </p>
                         <p class="list-group-item-text quicktext-tags" ng-if="template.tags">
-                        <div class="label-wrapper" ng-repeat="tag in template.tags.split(', ')">
+                        <div class="label-wrapper" ng-repeat="tag in getTags(template)">
                             <span class="tag" ng-if="tag">
                                 <strong ng-if="filterTags.indexOf(tag) !== -1"><i class="fa fa-hashtag icon"></i>{{tag}} </strong>
                                 <span ng-if="filterTags.indexOf(tag) === -1"><i class="fa fa-hashtag icon"></i>{{tag}} </span>


### PR DESCRIPTION
#### Fixes
- Fix issues with tags that contain spaces.
- When opening a template that has tags that contain spaces, the tags were not displayed in the Edit Template `selectize` input.
- This was caused by using `selectize.addOption` with tags from `TemplateService.allTags` - that removes spaces from tags, then using `selectize.addItem` with tags directly from `template.tags` - where tags still contained spaces.
- Fixed by getting the displayed tags from `TemplateService.tags` - to have spaces removed - instead of displaying them from `template.tags`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gorgias/gorgias-chrome/307)
<!-- Reviewable:end -->
