### PR TITLE
Fix template editor fixed height and unable to scroll content

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "gorgias",
-    "version": "6.1.1",
+    "version": "6.1.2",
     "description": "Gorgias grunt package",
     "main": "index.js",
     "scripts": {

--- a/src/background/css/list.styl
+++ b/src/background/css/list.styl
@@ -220,10 +220,6 @@
                                             flex: 1;
                                             display: flex;
                                             flex-direction: column;
-
-                                            #qt-body_ifr {
-                                                flex: 1;
-                                            }
                                         }
 
                                     }

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,7 +1,7 @@
 {
     "manifest_version": 2,
     "name": "__MSG_extName__",
-    "version": "6.1.1",
+    "version": "6.1.2",
     "description": "__MSG_extDesc__",
     "short_name": "Gorgias",
     "default_locale": "en",


### PR DESCRIPTION
#### Fixes
- The template editor height now expands depending on the content length.
- It had a fixed height, and was unable to scroll content.
- TinyMCE `autoresize` plugin was blocked by using a `flex` declaration on the container.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gorgias/gorgias-chrome/308)
<!-- Reviewable:end -->
