### PR TITLE
Sharing improvements in Firestore backend

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "gorgias",
-    "version": "6.2.1",
+    "version": "6.2.2",
     "description": "Gorgias grunt package",
     "main": "index.js",
     "scripts": {

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,7 +1,7 @@
 {
     "manifest_version": 2,
     "name": "__MSG_extName__",
-    "version": "6.2.1",
+    "version": "6.2.2",
     "description": "__MSG_extDesc__",
     "short_name": "Gorgias",
     "default_locale": "en",


### PR DESCRIPTION
#### Changes
- Fix issues with setting templates as shared with everyone in the Firestore backend.
- The `updateSharing` emails acl list will never include the current signed-in user, even if the template is owned by a different user, causing issues with detecting shared with everyone or custom sharing.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gorgias/gorgias-chrome/313)
<!-- Reviewable:end -->
