### PR TITLE
Sharing email notification for Firestore

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "gorgias",
-    "version": "6.2.2",
+    "version": "6.2.3",
     "description": "Gorgias grunt package",
     "main": "index.js",
     "scripts": {

--- a/src/background/css/list.styl
+++ b/src/background/css/list.styl
@@ -277,3 +277,8 @@
     margin-right: 15px;
 }
 
+/* inline email notification checkbox
+ */
+.template-share-notify input {
+    display: inline !important;
+}

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,7 +1,7 @@
 {
     "manifest_version": 2,
     "name": "__MSG_extName__",
-    "version": "6.2.2",
+    "version": "6.2.3",
     "description": "__MSG_extDesc__",
     "short_name": "Gorgias",
     "default_locale": "en",

--- a/src/pages/includes/form.html
+++ b/src/pages/includes/form.html
@@ -159,10 +159,10 @@
                                     </div>
                                 </div>
                                 <div class="col-xs-4" style="margin-top: 6px">
-                                    <p>Notify people by email : <input type="checkbox"
-                                                                       ng-model="templateForm.send_email"
-                                                                       ng-true-value="'true'" ng-false-value="'false'">
-                                    </p>
+                                    <label class="template-share-notify">
+                                        <input type="checkbox" ng-model="templateForm.send_email" ng-true-value="'true'" ng-false-value="'false'">
+                                        Notify people by email
+                                    </label>
                                 </div>
                             </div>
                         </div>

--- a/src/store/plugin-firestore.js
+++ b/src/store/plugin-firestore.js
@@ -1076,7 +1076,7 @@ var _FIRESTORE_PLUGIN = function () {
         return getSignedInUser()
             .then((res) => {
                 user = res;
-                return getMembers({exclude: []})
+                return getMembers({exclude: []});
             })
             .then((res) => {
                 members = res.members;
@@ -1115,15 +1115,15 @@ var _FIRESTORE_PLUGIN = function () {
 
                         // don't share with template owner
                         shared_with = shared_with.filter((memberId) => {
-                            return memberId !== owner
-                        })
+                            return memberId !== owner;
+                        });
 
                         // set notified users
-                        members.filter((member) => {
+                        members.forEach((member) => {
                             // exclude template owner
                             if(emails.includes(member.email) && member.id !== owner) {
                                 // map for deduplication
-                                notifiedUsers[member.id] = member
+                                notifiedUsers[member.id] = member;
                             }
                         });
 
@@ -1136,22 +1136,22 @@ var _FIRESTORE_PLUGIN = function () {
             }).then(() => {
                 // send_email is string
                 if (params.send_email === 'true') {
-                    var users = Object.keys(notifiedUsers).map((id) => notifiedUsers[id])
+                    var users = Object.keys(notifiedUsers).map((id) => notifiedUsers[id]);
                     shareNotification({
                         users: users,
                         templates: templateIds,
                         message: params.acl.message
-                    })
+                    });
                 }
 
                 return;
-            })
+            });
     };
 
     function shareNotification (params = {}) {
         return getCurrentUser()
             .then((currentUser) => {
-                return currentUser.getIdToken(true)
+                return currentUser.getIdToken(true);
             })
             .then((idToken) => {
                 return fetch(`${Config.functionsUrl}/share`, {
@@ -1168,7 +1168,7 @@ var _FIRESTORE_PLUGIN = function () {
                 })
                 .then(handleErrors)
                 .then((res) => res.json());
-            })
+            });
     }
 
     var getStats = mock;


### PR DESCRIPTION
- Send email notifications for shared templates when `Notify people by email` checkbox is checked, in Firestore plugin
- Use API endpoint for sending emails
- Improve checkbox layout, fix issues with text wrapping to next line, increase click area

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gorgias/gorgias-chrome/314)
<!-- Reviewable:end -->
