### PR TITLE
Hotfix remote template sync

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "gorgias",
-    "version": "6.3.0",
+    "version": "6.3.1",
     "description": "Gorgias grunt package",
     "main": "index.js",
     "scripts": {

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,7 +1,7 @@
 {
     "manifest_version": 2,
     "name": "__MSG_extName__",
-    "version": "6.3.0",
+    "version": "6.3.1",
     "description": "__MSG_extDesc__",
     "short_name": "Gorgias",
     "default_locale": "en",

--- a/src/store/plugin-api.js
+++ b/src/store/plugin-api.js
@@ -693,13 +693,6 @@ var _GORGIAS_API_PLUGIN = function () {
     };
 
     var syncNow = function () {
-        var hash = window.location.hash;
-        var inList = hash.indexOf('/list') !== -1;
-        if (!inList) {
-            // only sync when in list
-            return Promise.resolve();
-        }
-
         return getSettings({
             key: 'isLoggedIn'
         }).then(function (isLoggedIn) {


### PR DESCRIPTION
* Fix issues with remote templates not syncing, while using the Python API.
* `syncNow` didn't trigger the local sync because of checking `window.location`, which has changed after moving the store to the background script.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gorgias/gorgias-chrome/319)
<!-- Reviewable:end -->
