### PR TITLE
Import templates in Firestore

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "gorgias",
-    "version": "6.3.1",
+    "version": "6.3.2",
     "description": "Gorgias grunt package",
     "main": "index.js",
     "scripts": {

--- a/package.json
+++ b/package.json
@@ -86,6 +86,7 @@
         "mousetrap": "xarg/mousetrap#master",
         "ng-file-upload": "danialfarid/angular-file-upload-bower#~11.0.2",
         "npm": "^5.8.0",
+        "papaparse": "^5.1.0",
         "raven-js": "getsentry/raven-js#3.9.1",
         "selectize": "selectize/selectize.js#~0.12.1",
         "sifter": "brianreavis/sifter.js#0.5.x",

--- a/src/background/js/controllers/includes/import.js
+++ b/src/background/js/controllers/includes/import.js
@@ -2,18 +2,99 @@ gApp.controller('ImportCtrl', function ($scope, $rootScope, $timeout) {
     var self = this;
     self.uploading = false;
 
+    // legacy api import
+    var handleErrors = function (response) {
+        if (!response.ok) {
+            return response.clone().json().then((res) => {
+                return Promise.reject(res);
+            });
+        }
+        return response;
+    };
+
+    function legacyImport (params = {}) {
+        var formData = new FormData();
+        formData.append('file', params.file);
+        return fetch(`${Config.apiBaseURL}quicktexts/import`, {
+            method: 'POST',
+            body: formData
+        })
+        .then(handleErrors)
+        .then((res) => res.json());
+    }
+
+    // firebase import
+    function firebaseImport (params = {}) {
+        return new Promise((resolve, reject) => {
+            Papa.parse(params.file, {
+                header: true,
+                skipEmptyLines: true,
+                complete: (res) => {
+                    Promise.all(res.data.map((template) => {
+                        return importTemplate(template);
+                    })).then(resolve);
+                },
+                error: (err) => {
+                    reject(err);
+                }
+            });
+        });
+    }
+
+    // import a single template into firestore
+    function importTemplate (template = {}) {
+        return store.getTemplate().then((res) => {
+            // skip existing templates
+            var existing = res[template.id];
+            if (existing) {
+                return;
+            }
+
+            // we don't have a template with this id:
+            // - template doesn't have an id
+            // - template was deleted
+            // - template is from different account
+
+            // skip if we have a template with the same shortcut.
+            var existingShortcut = Object.keys(res).find((id) => {
+                return res[id].shortcut === template.shortcut;
+            });
+            if (existingShortcut) {
+                return;
+            }
+
+            delete template.id;
+            return store.createTemplate({
+                template: template
+            });
+        });
+    }
+
     self.onFileSelect = function (file) {
+        // file was already selected
+        if (!file) {
+            return;
+        }
+
         amplitude.getInstance().logEvent("Imported template");
 
         self.uploading = true;
-        return store.importTemplates({
+        var importParams = {
             file: file
-        }).then(() => {
-            $timeout(function() {
-                $rootScope.$broadcast('templates-sync');
-                self.uploading = false;
-                $('#import-modal').modal('hide');
-            }, 3000);
-        });
+        };
+        return store.importTemplates(importParams)
+            .then((res) => {
+                if (res.firebase) {
+                    return firebaseImport(importParams);
+                }
+
+                return legacyImport(importParams);
+            }).then(() => {
+                $timeout(function() {
+                    $rootScope.$broadcast('templates-sync');
+                    self.uploading = false;
+                    $('#import-modal').modal('hide');
+                }, 3000);
+            });
     };
 });

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,7 +1,7 @@
 {
     "manifest_version": 2,
     "name": "__MSG_extName__",
-    "version": "6.3.1",
+    "version": "6.3.2",
     "description": "__MSG_extDesc__",
     "short_name": "Gorgias",
     "default_locale": "en",

--- a/src/pages/views/includes/import_form.html
+++ b/src/pages/views/includes/import_form.html
@@ -11,20 +11,10 @@
                         <label for="import-input">Import</label><br/>
                         <input type="file" id="import-input" ngf-select="import.onFileSelect($file)" ngf-drop class="drop-box">
                         <br/>
-                            <h5>Supported formats:</h5>
-                            <ul>
-                                <li>
-                                    .csv files you export from Gorgias itself
-                                </li>
-                                <li>
-                                    <a href="https://smilesoftware.com/TextExpander/index.html" target="_blank">TextExpander</a>
-                                    .textexpander files
-                                </li>
-                                <li>
-                                    <a href="https://addons.mozilla.org/en-us/thunderbird/addon/quicktext/" target="_blank">Quicktext for Thunderbird</a> .xml files
-                                </li>
-                            </ul>
 
+                        <p>
+                            Select a <code>.csv</code> file that you previously exported from Gorgias Templates.
+                        </p>
                     </div>
                     <div id="file-upload-progress" class="progress progress-indefinite" ng-show="import.uploading">
                         <div class="progress-bar progress-bar-info" role="progressbar" aria-valuenow="0" aria-valuemin="0" aria-valuemax="100">

--- a/src/pages/views/list.html
+++ b/src/pages/views/list.html
@@ -20,8 +20,7 @@
                 href
                 class="btn btn-default"
                 data-toggle="modal"
-                data-target="#import-modal"
-                ng-show="!firestoreEnabled">
+                data-target="#import-modal">
                 Import
             </a>
         </div>

--- a/src/store/plugin-api.js
+++ b/src/store/plugin-api.js
@@ -840,14 +840,11 @@ var _GORGIAS_API_PLUGIN = function () {
     };
 
     var importTemplates = function (params = {}) {
-        var formData = new FormData();
-        formData.append('file', params.file);
-        return fetch(`${apiBaseURL}quicktexts/import`, {
-            method: 'POST',
-            body: formData
-        })
-        .then(handleErrors)
-        .then((res) => res.json());
+        // need to handle upload on the client.
+        // can't send file object through message.
+        return Promise.resolve({
+            firebase: false
+        });
     };
 
     return {

--- a/src/store/plugin-firestore.js
+++ b/src/store/plugin-firestore.js
@@ -1551,8 +1551,10 @@ var _FIRESTORE_PLUGIN = function () {
     // make impersonate public
     window.IMPERSONATE = impersonate;
 
-    // TODO import templates functionality
     var importTemplates = (params = {}) => {
+        return Promise.resolve({
+            firebase: true
+        });
     };
 
     var migrate = function () {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -63,6 +63,8 @@ const dependencies = {
 
                 'fuse.js/src/fuse.min.js',
 
+                'papaparse/papaparse.min.js',
+
                 './firebase/config-firebase.js',
                 './firebase/firebase.umd.js',
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -6713,6 +6713,11 @@ pako@~1.0.5:
   resolved "https://registry.yarnpkg.com/pako/-/pako-1.0.7.tgz#2473439021b57f1516c82f58be7275ad8ef1bb27"
   integrity sha512-3HNK5tW4x8o5mO8RuHZp3Ydw9icZXx0RANAOMzlMzx7LVXhMJ4mo3MOBpzyd7r/+RUu8BmndP47LXT+vzjtWcQ==
 
+papaparse@^5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/papaparse/-/papaparse-5.1.0.tgz#6228e8d96de99630ad017cf6522042319facc5eb"
+  integrity sha512-3jEYMiCc8qN7V5ffi2BTS2mRauKxCu5AIED6DxbjnHhIm7OY7fzKYkndfPlHWaaKUDCTml5XTU6V+hiuxGlZuw==
+
 parallel-transform@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/parallel-transform/-/parallel-transform-1.1.0.tgz#d410f065b05da23081fcd10f28854c29bda33b06"


### PR DESCRIPTION
* Import templates functionality for new Firestore backend.
* Fix issues with Import in the legacy API. There was an issue with sending the File object to the background script.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gorgias/gorgias-chrome/320)
<!-- Reviewable:end -->
