### PR TITLE
Temporary hotfix for large number of stats requests to API

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "gorgias",
-    "version": "6.3.2",
+    "version": "6.3.3",
     "description": "Gorgias grunt package",
     "main": "index.js",
     "scripts": {

--- a/src/background/js/app.js
+++ b/src/background/js/app.js
@@ -336,7 +336,7 @@ gApp.run(function ($rootScope, $location, $timeout, ProfileService, SettingsServ
     $rootScope.checkLoggedIn();
 
     // Setup recurring syncing interval
-    var syncInterval = 30 * 1000;
+    var syncInterval = 100 * 1000;
     window.setInterval(store.syncNow, syncInterval);
     store.syncNow();
 

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,7 +1,7 @@
 {
     "manifest_version": 2,
     "name": "__MSG_extName__",
-    "version": "6.3.2",
+    "version": "6.3.3",
     "description": "__MSG_extDesc__",
     "short_name": "Gorgias",
     "default_locale": "en",

--- a/src/store/plugin-api.js
+++ b/src/store/plugin-api.js
@@ -749,17 +749,22 @@ var _GORGIAS_API_PLUGIN = function () {
             .then((res) => res.json());
     };
 
+    // HACK temporarily disable the update stats method
     var updateStats = function (params = {}) {
-        return fetch(`${apiBaseURL}templates/stats`, {
-            method: 'POST',
-            headers: {
-                'Content-Type': 'application/json'
-            },
-            body: JSON.stringify(params)
-        })
-        .then(handleErrors)
-        .then((res) => res.json());
+        return Promise.resolve();
     };
+
+//     var updateStats = function (params = {}) {
+//         return fetch(`${apiBaseURL}templates/stats`, {
+//             method: 'POST',
+//             headers: {
+//                 'Content-Type': 'application/json'
+//             },
+//             body: JSON.stringify(params)
+//         })
+//         .then(handleErrors)
+//         .then((res) => res.json());
+//     };
 
     var getSubscription = function (params = {}) {
         var subscriptionsApiUrl = `${apiBaseURL}subscriptions`;


### PR DESCRIPTION
* Temporarily disable updating stats in old api, because of number of requests.
* Increase template sync interval in old api.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gorgias/gorgias-chrome/321)
<!-- Reviewable:end -->
