### PR TITLE
Iframe editor bugfix and API request improvements

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "gorgias",
-    "version": "6.3.4",
+    "version": "6.3.5",
     "description": "Gorgias grunt package",
     "main": "index.js",
     "scripts": {

--- a/src/background/js/services/account.js
+++ b/src/background/js/services/account.js
@@ -1,12 +1,18 @@
-gApp.service('AccountService', function ($q, $rootScope) {
+gApp.service('AccountService', function ($q, $rootScope, SettingsService) {
     var self = this;
 
     self.get = function () {
         var deferred = $q.defer();
 
-        store.getAccount().then((user) => {
-            self.user = user;
-            deferred.resolve(user);
+        SettingsService.get('isLoggedIn').then(function (isLoggedIn) {
+            if (!isLoggedIn) {
+                return deferred.reject();
+            }
+
+            store.getAccount().then((user) => {
+                self.user = user;
+                deferred.resolve(user);
+            });
         });
 
         return deferred.promise;

--- a/src/content/js/dialog.js
+++ b/src/content/js/dialog.js
@@ -134,6 +134,11 @@ App.autocomplete.dialog = {
         });
     },
     createQaBtn: function () {
+        // only on whitelisted domains
+        if (!App.autocomplete.dialog.qaBtnWhitelist.includes(window.location.origin)) {
+            return;
+        }
+
         var container = $('body');
 
         var instance = this;
@@ -563,10 +568,7 @@ App.autocomplete.dialog = {
         store.getSettings({
             key: 'settings'
         }).then((settings) => {
-            if ((settings.qaBtn && settings.qaBtn.enabled === false) ||
-                // only show for whitelisted domains
-                App.autocomplete.dialog.qaBtnWhitelist.indexOf(window.location.origin) === -1
-            ) {
+            if (settings.qaBtn && settings.qaBtn.enabled === false) {
                 return;
             }
 

--- a/src/content/js/index.js
+++ b/src/content/js/index.js
@@ -295,7 +295,13 @@ App.init = function(settings, doc) {
             App.autocomplete.keyboard.completion
         );
     }
-    if (settings.dialog.enabled) {
+
+    var isContentEditable = (window.document.body.contentEditable === 'true');
+    if (
+        settings.dialog.enabled &&
+        // don't create the dialog inside editor iframes (eg. tinymce iframe)
+        !isContentEditable
+    ) {
         if (settings.qaBtn.enabled) {
             App.autocomplete.dialog.createQaBtn();
         }

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,7 +1,7 @@
 {
     "manifest_version": 2,
     "name": "__MSG_extName__",
-    "version": "6.3.4",
+    "version": "6.3.5",
     "description": "__MSG_extDesc__",
     "short_name": "Gorgias",
     "default_locale": "en",

--- a/src/store/plugin-api.js
+++ b/src/store/plugin-api.js
@@ -438,18 +438,28 @@ var _GORGIAS_API_PLUGIN = function () {
                     if (!onlyLocal) {
                         amplitude.getInstance().logEvent("Deleted template");
                     }
-                    queryTemplates({
-                        quicktextId: t.remote_id
-                    }).then(function (remote) {
-                        // make sure we have the remote id otherwise the delete will not find the right resource
-                        remote.remote_id = remote.id;
-                        deleteRemoteTemplate(remote)
-                        .then(() => {
-                            // Do a local "DELETE" only if deleted remotely.
-                            // If remote operation fails, try again when syncing.
-                            //
-                            // NOTE: We delete locally to save space.
-                            TemplateStorage.remove(t.id, resolve);
+
+                    return getSettings({
+                        key: 'isLoggedIn'
+                    }).then(function (isLoggedIn) {
+                        // bail if not logged-in
+                        if (!isLoggedIn) {
+                            return resolve();
+                        }
+
+                        queryTemplates({
+                            quicktextId: t.remote_id
+                        }).then(function (remote) {
+                            // make sure we have the remote id otherwise the delete will not find the right resource
+                            remote.remote_id = remote.id;
+                            deleteRemoteTemplate(remote)
+                            .then(() => {
+                                // Do a local "DELETE" only if deleted remotely.
+                                // If remote operation fails, try again when syncing.
+                                //
+                                // NOTE: We delete locally to save space.
+                                TemplateStorage.remove(t.id, resolve);
+                            });
                         });
                     });
                 });


### PR DESCRIPTION
* Fix issues with the dialog html markup showing up in editors that use full `contenteditable` iframes. Issue was reported on shopify.com and prescreen.io.
* Don't trigger API template delete request when not logged-in.
* Don't trigger API account request when not logged-in.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gorgias/gorgias-chrome/323)
<!-- Reviewable:end -->
