### PR TITLE
Fix "Duplicate template" functionality in Firestore

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "gorgias",
-    "version": "6.3.5",
+    "version": "6.3.6",
     "description": "Gorgias grunt package",
     "main": "index.js",
     "scripts": {

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,7 +1,7 @@
 {
     "manifest_version": 2,
     "name": "__MSG_extName__",
-    "version": "6.3.5",
+    "version": "6.3.6",
     "description": "__MSG_extDesc__",
     "short_name": "Gorgias",
     "default_locale": "en",


### PR DESCRIPTION
* Fix issues with duplicating templates using the "Duplicate template" button when using the Firestore backend. The issue was caused by not converting Firestore timestamps.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gorgias/gorgias-chrome/324)
<!-- Reviewable:end -->
