### PR TITLE
Remove migrated legacy templates

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "gorgias",
-    "version": "6.3.6",
+    "version": "6.3.7",
     "description": "Gorgias grunt package",
     "main": "index.js",
     "scripts": {

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,7 +1,7 @@
 {
     "manifest_version": 2,
     "name": "__MSG_extName__",
-    "version": "6.3.6",
+    "version": "6.3.7",
     "description": "__MSG_extDesc__",
     "short_name": "Gorgias",
     "default_locale": "en",

--- a/src/store/plugin-firestore.js
+++ b/src/store/plugin-firestore.js
@@ -281,6 +281,8 @@ var _FIRESTORE_PLUGIN = function () {
                                 templates: [
                                     Object.assign({id: remoteId}, res)
                                 ]
+                            }).then(() => {
+                                return localId;
                             });
                         });
                     }
@@ -288,6 +290,11 @@ var _FIRESTORE_PLUGIN = function () {
                     return;
                 })
             );
+        }).then((ids = []) => {
+            const migratedTemplates = ids.filter((id) => !!id);
+            // delete legacy data
+            chrome.storage.local.remove(migratedTemplates);
+            return;
         });
     }
 


### PR DESCRIPTION
* Remove legacy templates after migrating them to the new Firestore format.
* Prevents using up too much space in the local chrome storage.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gorgias/gorgias-chrome/325)
<!-- Reviewable:end -->
