### PR TITLE
Fix issues with reactivating old subscriptions

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "gorgias",
-    "version": "6.3.10",
+    "version": "6.3.11",
     "description": "Gorgias grunt package",
     "main": "index.js",
     "scripts": {

--- a/src/background/js/app.js
+++ b/src/background/js/app.js
@@ -218,16 +218,28 @@ gApp.run(function ($rootScope, $location, $timeout, ProfileService, SettingsServ
         });
     }
 
+    $rootScope.updateFirebaseCreditCard = function (params = {}) {
+        var stripe = Stripe(params.stripeKey);
+        stripe.redirectToCheckout({
+            sessionId: params.id
+        }).then(function (result) {
+            if (result && result.error && result.error.message) {
+                alert(result.error.message);
+                return;
+            }
+        });
+    };
+
     // Get a new token from stripe and send it to the server
     $rootScope.reactivateSubscription = function () {
         $rootScope.loadingSubscription = true;
         var reactivateParams = {
             subscription: $rootScope.currentSubscription
         };
+
         store.reactivateSubscription(reactivateParams).then((res = {}) => {
             if (res.firebase) {
-                window.location.reload();
-                return;
+                return $rootScope.updateFirebaseCreditCard(res);
             }
 
             return reactivateLegacySubscription(reactivateParams).then((token) => {

--- a/src/background/js/controllers/account/subscriptions.js
+++ b/src/background/js/controllers/account/subscriptions.js
@@ -68,18 +68,6 @@ gApp.controller('SubscriptionsCtrl', function ($scope, $rootScope, $routeParams,
         });
     }
 
-    function updateFirebaseCreditCard (params = {}) {
-        var stripe = Stripe(params.stripeKey);
-        stripe.redirectToCheckout({
-            sessionId: params.id
-        }).then(function (result) {
-            if (result && result.error && result.error.message) {
-                alert(result.error.message);
-                return;
-            }
-        });
-    }
-
     // Get a new token from stripe and send it to the server
     $scope.updateCC = function () {
         $scope.paymentMsg = '';
@@ -93,7 +81,7 @@ gApp.controller('SubscriptionsCtrl', function ($scope, $rootScope, $routeParams,
         };
         store.updateCreditCard(ccParams).then((res) => {
             if (res.firebase) {
-                return updateFirebaseCreditCard(Object.assign(res, ccParams));
+                return $rootScope.updateFirebaseCreditCard(Object.assign(res, ccParams));
             }
 
             return updateLegacyCreditCard(ccParams).then((token) => {
@@ -101,7 +89,7 @@ gApp.controller('SubscriptionsCtrl', function ($scope, $rootScope, $routeParams,
                 SubscriptionService.updateSubscription($scope.activeSubscription.id, {token: token}).then(
                     function (res) {
                         $('.update-cc-btn').removeClass('disabled');
-                        $scope.paymentMsg = res
+                        $scope.paymentMsg = res;
                         $scope.reloadSubscriptions();
                     }, function (res) {
                         $('.update-cc-btn').removeClass('disabled');
@@ -109,7 +97,7 @@ gApp.controller('SubscriptionsCtrl', function ($scope, $rootScope, $routeParams,
                     }
                 );
             });
-        })
+        });
     };
 
     $scope.updateSubscription = function (plan, quantity) {
@@ -134,7 +122,7 @@ gApp.controller('SubscriptionsCtrl', function ($scope, $rootScope, $routeParams,
 
     $scope.cancelSubscription = function() {
         $scope.loadingCancel = true;
-        cancelConfirm = window.confirm('Are you sure you want to cancel and delete all your template backups?')
+        cancelConfirm = window.confirm('Are you sure you want to cancel and delete all your template backups?');
         if (cancelConfirm === true) {
             SubscriptionService.cancelSubscription().then(function () {
                 $rootScope.logOut();

--- a/src/background/js/controllers/includes/template_form.js
+++ b/src/background/js/controllers/includes/template_form.js
@@ -94,7 +94,7 @@ gApp.controller('TemplateFormCtrl',
                                     { text: 'Date: Last week', onclick: function() {self.insertVar('date \'-7\' \'days\' \'YYYY-MM-DD\'');}},
                                     { text: 'Random choice', onclick: function() {self.insertVar('choice \'Hello, Hi, Hey\'');}},
                                     { text: 'Extract domain', onclick: function() {self.insertVar('domain to.email');}},
-                                    { text: 'Learn more about template variables', onclick: function() {window.open("http://docs.gorgias.io/chrome-extension/templates#Template_Variables");}},
+                                    { text: 'Learn more about template variables', onclick: function() {window.open("https://templates-help.gorgias.io/templates/templates#template_variables");}},
                                 ]
                             });
 

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,7 +1,7 @@
 {
     "manifest_version": 2,
     "name": "__MSG_extName__",
-    "version": "6.3.10",
+    "version": "6.3.11",
     "description": "__MSG_extDesc__",
     "short_name": "Gorgias",
     "default_locale": "en",

--- a/src/pages/options.html
+++ b/src/pages/options.html
@@ -95,7 +95,7 @@
             <strong>Your current subscription is no longer active.</strong>
             <p>This means that automatic syncing and backup of templates has been disabled for you and your team.</p>
             <p>
-                <em>Note: without <a href="http://docs.gorgias.io/chrome-extension/template-synchronization" target="_blank">template
+                <em>Note: without <a href="https://templates-help.gorgias.io/templates/template-synchronization" target="_blank">template
                     synchronisation</a> you risk losing all your templates
                     (if you delete the extension or re-install Chrome).</em>
             </p>


### PR DESCRIPTION
* Fix reactivating old subscriptions migrated to Firestore, because of expired payment methods.
* Always update credit card when reactivating subscriptions. 
* Remove the `subscription/reactivate` request.
* Improvements to the customer/subscription change listeners.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gorgias/gorgias-chrome/334)
<!-- Reviewable:end -->
