### PR TITLE
Fix adding extra newlines when the rich-text editor is disabled

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "gorgias",
-    "version": "6.3.12",
+    "version": "6.3.13",
     "description": "Gorgias grunt package",
     "main": "index.js",
     "scripts": {

--- a/src/content/js/autocomplete.js
+++ b/src/content/js/autocomplete.js
@@ -215,9 +215,6 @@ App.autocomplete.replaceWith = function (params) {
 
                 replacement = parsedTemplate;
 
-                if (!App.settings.editor_enabled) {
-                    replacement = replacement.replace(/\n/g, ' <br />\n');
-                }
                 // setStart/setEnd work differently based on
                 // the type of node
                 // https://developer.mozilla.org/en-US/docs/Web/API/range.setStart

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,7 +1,7 @@
 {
     "manifest_version": 2,
     "name": "__MSG_extName__",
-    "version": "6.3.12",
+    "version": "6.3.13",
     "description": "__MSG_extDesc__",
     "short_name": "Gorgias",
     "default_locale": "en",


### PR DESCRIPTION
* Fix issues with adding too many newlines in `contenteditable` containers, when the rich-text editor is disabled.
* Replacing newline char with `<br>` tags were adding an extra newline. `Contenteditable` supports the newline tag, so we don't need to replace it with br.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gorgias/gorgias-chrome/336)
<!-- Reviewable:end -->
