### PR TITLE
Fix missing variable data in extra fields

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "gorgias",
-    "version": "6.4.0",
+    "version": "6.4.1",
     "description": "Write everything faster.",
     "main": "index.js",
     "scripts": {

--- a/src/content/js/plugins/fastmail.js
+++ b/src/content/js/plugins/fastmail.js
@@ -76,16 +76,16 @@ function isHidden (el) {
     return (el.offsetParent === null);
 }
 
-function before (params) {
+function before (params, data) {
     var $parent = $(params.element).closest('.v-Compose');
 
     if (params.quicktext.subject) {
-        var parsedSubject = parseTemplate(params.quicktext.subject, params.data);
+        var parsedSubject = parseTemplate(params.quicktext.subject, data);
         $('input[id$="subject-input"]', $parent).val(parsedSubject);
     }
 
     if (params.quicktext.to) {
-        var parsedTo = parseTemplate(params.quicktext.to, params.data);
+        var parsedTo = parseTemplate(params.quicktext.to, data);
         var $toField = $('textarea[id$="to-input"]', $parent);
         $toField.val(parsedTo);
 
@@ -96,7 +96,7 @@ function before (params) {
     var $btns = $('.v-Compose-addCcBcc .u-subtleLink', $parent);
 
     if (params.quicktext.cc) {
-        var parsedCc = parseTemplate(params.quicktext.cc, params.data);
+        var parsedCc = parseTemplate(params.quicktext.cc, data);
 
         var $ccField = $('textarea[id$="cc-input"]', $parent);
 
@@ -114,7 +114,7 @@ function before (params) {
     }
 
     if (params.quicktext.bcc) {
-        var parsedBcc = parseTemplate(params.quicktext.bcc, params.data);
+        var parsedBcc = parseTemplate(params.quicktext.bcc, data);
 
         var $bccField = $('textarea[id$="bcc-input"]', $parent);
 
@@ -156,7 +156,7 @@ export default (params = {}) => {
     var data = getData(params);
     var parsedTemplate = parseTemplate(params.quicktext.body, data);
 
-    before(params);
+    before(params, data);
 
     insertText(Object.assign({
         text: parsedTemplate

--- a/src/content/js/plugins/gmail.js
+++ b/src/content/js/plugins/gmail.js
@@ -111,14 +111,14 @@ function getData (params) {
         bcc: parseList(bcc),
         subject: subject,
         plugin: 'gmail'//maybe there is another way to get the active plugin..
-    };
+   };
 }
 
-function before (params) {
+function before (params, data) {
     var $parent = $(params.element).closest('table.aoP');
 
     if (params.quicktext.subject) {
-        var parsedSubject = parseTemplate(params.quicktext.subject, params.data);
+        var parsedSubject = parseTemplate(params.quicktext.subject, data);
         $parent.find('input[name=subjectbox]').val(parsedSubject);
     }
 
@@ -133,12 +133,12 @@ function before (params) {
     }
 
     if (params.quicktext.to) {
-        var parsedTo = parseTemplate(params.quicktext.to, params.data);
+        var parsedTo = parseTemplate(params.quicktext.to, data);
         $parent.find('textarea[name=to]').val(parsedTo);
     }
 
     if (params.quicktext.cc) {
-        var parsedCc = parseTemplate(params.quicktext.cc, params.data);
+        var parsedCc = parseTemplate(params.quicktext.cc, data);
 
         // click the cc button
         $parent.find('.aB.gQ.pE').trigger('click');
@@ -147,7 +147,7 @@ function before (params) {
     }
 
     if (params.quicktext.bcc) {
-        var parsedBcc = parseTemplate(params.quicktext.bcc, params.data);
+        var parsedBcc = parseTemplate(params.quicktext.bcc, data);
 
         // click the bcc button
         $parent.find('.aB.gQ.pB').trigger('click');
@@ -315,7 +315,7 @@ export default (params = {}) => {
     var data = getData(params);
     var parsedTemplate = parseTemplate(params.quicktext.body, data);
 
-    before(params);
+    before(params, data);
 
     insertText(Object.assign({
         text: parsedTemplate

--- a/src/content/js/plugins/outlook.js
+++ b/src/content/js/plugins/outlook.js
@@ -184,7 +184,7 @@ function getData () {
     return vars;
 }
 
-function before (params) {
+function before (params, data) {
     // don't do anything if we don't have any extra fields
     if (!params.quicktext.subject &&
         !params.quicktext.to &&
@@ -196,7 +196,7 @@ function before (params) {
 
     var $subject = getSubjectField();
     if (params.quicktext.subject && $subject) {
-        var parsedSubject = parseTemplate(params.quicktext.subject, params.data);
+        var parsedSubject = parseTemplate(params.quicktext.subject, data);
         $subject.value = parsedSubject;
         $subject.dispatchEvent(new Event('input', {bubbles: true}));
     }
@@ -205,7 +205,7 @@ function before (params) {
 
     var $to = $containers[1];
     if (params.quicktext.to) {
-        var parsedTo = parseTemplate(params.quicktext.to, params.data);
+        var parsedTo = parseTemplate(params.quicktext.to, data);
         if ($to && !elementContains($to, parsedTo)) {
             var $toInput = getContactField($to);
             updateContactField($toInput, parsedTo, params.element);
@@ -214,7 +214,7 @@ function before (params) {
 
     var $cc = $containers[2];
     if (params.quicktext.cc) {
-        var parsedCc = parseTemplate(params.quicktext.cc, params.data);
+        var parsedCc = parseTemplate(params.quicktext.cc, data);
         updateSection(
             $cc,
             $containers[0].querySelector('.ms-Button-label:first-of-type'),
@@ -226,7 +226,7 @@ function before (params) {
 
     var $bcc = $containers[3];
     if (params.quicktext.bcc) {
-        var parsedBcc = parseTemplate(params.quicktext.bcc, params.data);
+        var parsedBcc = parseTemplate(params.quicktext.bcc, data);
         updateSection(
             $bcc,
             $containers[0].querySelector('.ms-Button-label:last-of-type'),
@@ -271,7 +271,7 @@ export default (params = {}) => {
     var data = getData(params);
     var parsedTemplate = parseTemplate(params.quicktext.body, data);
 
-    return before(params).then((newParams) => {
+    return before(params, data).then((newParams) => {
         insertText(Object.assign({
             text: parsedTemplate
         }, newParams));

--- a/src/content/js/plugins/yahoo.js
+++ b/src/content/js/plugins/yahoo.js
@@ -78,11 +78,11 @@ function getData (params) {
     return vars;
 }
 
-function before (params) {
+function before (params, data) {
     var $parent = $(params.element).closest('[data-test-id="compose"]');
 
     if (params.quicktext.subject) {
-        var parsedSubject = parseTemplate(params.quicktext.subject, params.data);
+        var parsedSubject = parseTemplate(params.quicktext.subject, data);
         var $subjectField = $('[data-test-id="compose-subject"]', $parent);
         $subjectField.val(parsedSubject);
         $subjectField.get(0).dispatchEvent(new Event('input', {bubbles: true}));
@@ -90,7 +90,7 @@ function before (params) {
 
     // BUG to/cc/bcc fields stopped working
 //     if (params.quicktext.to) {
-//         var parsedTo = parseTemplate(params.quicktext.to, params.data);
+//         var parsedTo = parseTemplate(params.quicktext.to, data);
 //         var $toField = $('[data-test-id="compose-header-field-to"]', $parent);
 //         $toField.val(parsedTo);
 //
@@ -105,7 +105,7 @@ function before (params) {
 //     }
 //
 //     if (params.quicktext.cc) {
-//         var parsedCc = parseTemplate(params.quicktext.cc, params.data);
+//         var parsedCc = parseTemplate(params.quicktext.cc, data);
 //         var $ccField = $('[data-test-id="compose-header-field-cc"]', $parent);
 //         $ccField.val(parsedCc);
 //
@@ -113,7 +113,7 @@ function before (params) {
 //     }
 //
 //     if (params.quicktext.bcc) {
-//         var parsedBcc = parseTemplate(params.quicktext.bcc, params.data);
+//         var parsedBcc = parseTemplate(params.quicktext.bcc, data);
 //         var $bccField = $('[data-test-id="compose-header-field-bcc"]', $parent);
 //         $bccField.val(parsedBcc);
 //
@@ -147,7 +147,7 @@ export default (params = {}) => {
     var data = getData(params);
     var parsedTemplate = parseTemplate(params.quicktext.body, data);
 
-    before(params);
+    before(params, data);
 
     insertText(Object.assign({
         text: parsedTemplate

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,7 +1,7 @@
 {
     "manifest_version": 2,
     "name": "__MSG_extName__",
-    "version": "6.4.0",
+    "version": "6.4.1",
     "description": "__MSG_extDesc__",
     "short_name": "Gorgias",
     "default_locale": "en",


### PR DESCRIPTION
* Fix missing variable data in extra fields (subject/to/cc/bcc).
* Variable data was missing in `before` methods after switching to the new plugin system because we stopped mutating `params`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gorgias/gorgias-chrome/339)
<!-- Reviewable:end -->
