### PR TITLE
Fix splitString handlebars helper

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "gorgias",
-    "version": "6.4.5",
+    "version": "6.4.6",
     "description": "Write everything faster.",
     "main": "index.js",
     "scripts": {

--- a/src/content/js/content-helpers.js
+++ b/src/content/js/content-helpers.js
@@ -28,13 +28,11 @@ Handlebars.registerHelper('or', function (first, second) {
 Handlebars.registerHelper("splitString", function (context, options) {
     if (context) {
         var ret = "";
-        var data = Handlebars.createFrame({});
 
         var tempArr = context.trim().split(options.hash.delimiter);
         for (var i = 0; i < tempArr.length; i++) {
+            var data = Handlebars.createFrame(options.data || {});
             if (options.data) {
-                // update data
-                data = Handlebars.createFrame(options.data);
                 data.index = i;
             }
             if (typeof options.hash.index !== "undefined" && options.hash.index === i) {

--- a/src/content/js/content-helpers.js
+++ b/src/content/js/content-helpers.js
@@ -28,11 +28,13 @@ Handlebars.registerHelper('or', function (first, second) {
 Handlebars.registerHelper("splitString", function (context, options) {
     if (context) {
         var ret = "";
+        var data = Handlebars.createFrame({});
 
         var tempArr = context.trim().split(options.hash.delimiter);
         for (var i = 0; i < tempArr.length; i++) {
             if (options.data) {
-                data = Handlebars.createFrame(options.data || {});
+                // update data
+                data = Handlebars.createFrame(options.data);
                 data.index = i;
             }
             if (typeof options.hash.index !== "undefined" && options.hash.index === i) {

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,7 +1,7 @@
 {
     "manifest_version": 2,
     "name": "__MSG_extName__",
-    "version": "6.4.5",
+    "version": "6.4.6",
     "description": "__MSG_extDesc__",
     "short_name": "Gorgias",
     "default_locale": "en",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -164,7 +164,8 @@ const contentConfig = {
     devServer: {
         inline: false,
         writeToDisk: true
-    }
+    },
+    devtool: 'eval'
 };
 
 const storeConfig = (mode) => {


### PR DESCRIPTION
* Fix issues with the `splitString` Handlebars helper not working because of missing data.
* Add `eval` sourcemaps to the content script in development.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gorgias/gorgias-chrome/344)
<!-- Reviewable:end -->
