### PR TITLE
Fix issues with removing users on shared templates

### DIFF
--- a/src/store/plugin-firestore.js
+++ b/src/store/plugin-firestore.js
@@ -1117,8 +1117,15 @@ function deleteSharing (params = {}) {
                 });
             });
 
+            return;
+        }).catch((err) => {
+            // catch errors, to always clean-up the queue
+            return;
+        }).then(() => {
+            // clean-up
             batchDeleteSharing = null;
             listDeleteSharing = [];
+            return;
         });
     }, 1000);
 
@@ -1299,7 +1306,7 @@ var getSubscription = (params = {}) => {
             if (!plan) {
                 plan = {
                     name: subscriptionData.plan
-                }
+                };
             }
             var subscription = Object.assign(subscriptionData, {
                 active: active,


### PR DESCRIPTION
* Fix issues with removing individual users from the `shared_width` list.
* When we got an error on removing users from shared_with, the removal queue stayed full and threw errors on each template share update.
* Clean-up the share delete queue even on errors.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gorgias/gorgias-chrome/346)
<!-- Reviewable:end -->
