### PR TITLE
Fix conflict with the Loom extension

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "gorgias",
-    "version": "6.6.2",
+    "version": "6.6.3",
     "description": "Write everything faster.",
     "main": "index.js",
     "scripts": {

--- a/src/content/js/utils.js
+++ b/src/content/js/utils.js
@@ -53,7 +53,6 @@ export function insertText (params = {}) {
     var word = params.word;
 
     if (isContentEditable(params.element)) {
-
         var selection = doc.getSelection();
         var range = doc.createRange();
 
@@ -65,10 +64,24 @@ export function insertText (params = {}) {
             focusNode = selection.focusNode;
         }
 
+        // Loom Chrome extension causes the focusNode to always be an element
+        // on certain websites.
         // we need to have a text node in the end
         while (focusNode.nodeType === document.ELEMENT_NODE) {
             if (focusNode.childNodes.length > 0) {
-                focusNode = focusNode.childNodes[selection.focusOffset]; // select a text node
+                // when focusNode can have child nodes,
+                // focusOffset is the index in the childNodes collection
+                // of the focus node where the selection ends.
+                var focusOffset = selection.focusOffset;
+                // *but* if the focus point is placed after the anchor point,
+                // (when we insert templates with the shortcut, not from the dialog),
+                // the focus point is the first position after (not part of the selection),
+                // therefore focusOffset can be equal to the length of focusNode childNodes.
+                if (selection.focusOffset === focusNode.childNodes.length) {
+                    focusOffset = selection.focusOffset - 1;
+                }
+                // select a text node
+                focusNode = focusNode.childNodes[focusOffset];
             } else {
                 // create an empty text node
                 var tnode = doc.createTextNode('');

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,7 +1,7 @@
 {
     "manifest_version": 2,
     "name": "__MSG_extName__",
-    "version": "6.6.2",
+    "version": "6.6.3",
     "description": "__MSG_extDesc__",
     "short_name": "Gorgias",
     "default_locale": "en",


### PR DESCRIPTION
* The [Loom Chrome extension](https://chrome.google.com/webstore/detail/loom-video-recorder-scree/liecbddmkiiihnedobmlmillhodjkdmb) (and probably others) causes the `focusNode` to always be an element.
* There was an issue when we tried to get a text node starting from a `focusNode` element, when the `focusOffset` was set after the anchor, preventing templates from being inserted.
* Improvements to the way we get a text node starting from the `focusNode` element. Fixes #355 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gorgias/gorgias-chrome/359)
<!-- Reviewable:end -->
