### PR TITLE
Improve template insert speed on Firestore

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "gorgias",
-    "version": "6.6.3",
+    "version": "6.6.4",
     "description": "Write everything faster.",
     "main": "index.js",
     "scripts": {

--- a/src/background/js/services/stats.js
+++ b/src/background/js/services/stats.js
@@ -31,12 +31,8 @@ export default function StatsService ($q, $rootScope, SettingsService) {
                         SettingsService.get('syncedWords').then(function (syncedWords) {
                             var newWords = words - syncedWords;
                             if (newWords > 0) {
-                                store.updateStats({
-                                    words: newWords
-                                }).then(() => {
-                                    SettingsService.set("syncedWords", words);
-                                    SettingsService.set("lastStatsSync", new Date());
-                                });
+                                SettingsService.set("syncedWords", words);
+                                SettingsService.set("lastStatsSync", new Date());
                             }
                         });
                     });

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,7 +1,7 @@
 {
     "manifest_version": 2,
     "name": "__MSG_extName__",
-    "version": "6.6.3",
+    "version": "6.6.4",
     "description": "__MSG_extDesc__",
     "short_name": "Gorgias",
     "default_locale": "en",

--- a/src/store/chrome-config.js
+++ b/src/store/chrome-config.js
@@ -7,28 +7,6 @@ function resetSettings () {
     });
 }
 
-function updateTemplateStats (id) {
-    return window.store.getTemplate({
-        id: id
-    }).then((res) => {
-        var template = res[id];
-        if (typeof template.use_count === 'undefined') {
-            template.use_count = 0;
-        }
-
-        template.use_count++;
-        template.lastuse_datetime = new Date().toISOString();
-
-        return window.store.updateTemplate({
-            template: template,
-            synced: true,
-            onlyLocal: true,
-            // only used by firestore plugin
-            stats: true
-        });
-    });
-}
-
 // Register Chrome runtime protocols and context menus
 if (chrome.extension) {
 
@@ -142,9 +120,6 @@ if (chrome.extension) {
             window.open(chrome.extension.getURL('/pages/options.html') + '#/list');
         }
         if (request.request === 'track') {
-            if (request.event === "Inserted template") {
-                updateTemplateStats(request.data.id);
-            }
             amplitude.getInstance().logEvent(request.event, request.data);
         }
         return true;

--- a/src/store/plugin-api.js
+++ b/src/store/plugin-api.js
@@ -1,3 +1,4 @@
+/* globals console */
 // chrome.gorgias.io API plugin
 import _ from 'underscore';
 
@@ -713,19 +714,6 @@ var syncLocal = function () {
                             quicktextId: t.remote_id
                         }).then(update(Object.assign({}, t)));
                     }
-                }
-
-                // send stats to server if we templates used
-                if (t.use_count) { // if we have a use_count, then we can update the stats on the server.
-                    // we need this closure to make sure we don't duplicate the same template
-                    var saveCount = function (ut) {
-                        return function () {
-                            ut.use_count = 0;
-                            var data = {};
-                            data[ut.id] = ut;
-                            TemplateStorage.set(data, function () {});
-                        };
-                    };
                 }
             }
         }

--- a/src/store/plugin-api.js
+++ b/src/store/plugin-api.js
@@ -726,12 +726,6 @@ var syncLocal = function () {
                             TemplateStorage.set(data, function () {});
                         };
                     };
-
-                    updateStats({
-                        quicktext_id: t.remote_id,
-                        key: 'use_count',
-                        value: t.use_count
-                    }).then(saveCount(_deepClone(t)));
                 }
             }
         }
@@ -797,23 +791,6 @@ var getStats = function () {
         .then(handleErrors)
         .then((res) => res.json());
 };
-
-// HACK temporarily disable the update stats method
-var updateStats = function () {
-    return Promise.resolve();
-};
-
-//     var updateStats = function (params = {}) {
-//         return fetch(`${apiBaseURL}templates/stats`, {
-//             method: 'POST',
-//             headers: {
-//                 'Content-Type': 'application/json'
-//             },
-//             body: JSON.stringify(params)
-//         })
-//         .then(handleErrors)
-//         .then((res) => res.json());
-//     };
 
 var getSubscription = function (params = {}) {
     var subscriptionsApiUrl = `${apiBaseURL}subscriptions`;
@@ -926,7 +903,6 @@ export default {
     updateSharing: updateSharing,
 
     getStats: getStats,
-    updateStats: updateStats,
 
     getPlans: getPlans,
     getSubscription: getSubscription,

--- a/src/store/plugin-firestore.js
+++ b/src/store/plugin-firestore.js
@@ -874,24 +874,18 @@ var updateTemplate = (params = {}) => {
     var updatedDate = now();
     var updatedTemplate = {};
 
-    if (params.stats) {
-        // only update stats
-        updatedTemplate.lastuse_datetime = updatedDate;
-        updatedTemplate.use_count = params.template.use_count || 0;
-    } else {
-        var stringProps = ['title', 'body', 'shortcut', 'subject', 'to', 'cc', 'bcc'];
-        stringProps.forEach((prop) => {
-            if (params.template.hasOwnProperty(prop)) {
-                updatedTemplate[prop] = params.template[prop] || '';
-            }
-        });
-
-        if (params.template.hasOwnProperty('attachments')) {
-            updatedTemplate.attachments = params.template.attachments || [];
+    var stringProps = ['title', 'body', 'shortcut', 'subject', 'to', 'cc', 'bcc'];
+    stringProps.forEach((prop) => {
+        if (params.template.hasOwnProperty(prop)) {
+            updatedTemplate[prop] = params.template[prop] || '';
         }
+    });
 
-        updatedTemplate.modified_datetime = updatedDate;
+    if (params.template.hasOwnProperty('attachments')) {
+        updatedTemplate.attachments = params.template.attachments || [];
     }
+
+    updatedTemplate.modified_datetime = updatedDate;
 
     var templateTags = tagsToArray(params.template.tags);
     return tagsToIds(templateTags)
@@ -1268,7 +1262,6 @@ function shareNotification (params = {}) {
 }
 
 var getStats = mock;
-var updateStats = mock;
 
 var getPlans = () => {
     return getUserToken().then((res) => {
@@ -1656,7 +1649,6 @@ export default {
     updateSharing: updateSharing,
 
     getStats: getStats,
-    updateStats: updateStats,
 
     getPlans: getPlans,
     getSubscription: getSubscription,

--- a/src/store/store-client.js
+++ b/src/store/store-client.js
@@ -44,7 +44,6 @@ var methods = [
     'updateSharing',
 
     'getStats',
-    'updateStats',
 
     'getPlans',
     'getSubscription',


### PR DESCRIPTION
* Updating template usage stats when inserting templates was slowing down template insert, when using Firestore.
* Remove the usage count stats on templates, they are not used in the UI right now.
* Existing word/time-saved stats on the client-side are still functional.
* Existing server-side stats template usage stats are now read-only, available only for the old api.
* We'll implement new stats functionality for the new api later on.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gorgias/gorgias-chrome/360)
<!-- Reviewable:end -->
