### PR TITLE
Fix issues with opening the New Template modal from the Templates Dialog

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "gorgias",
-    "version": "6.6.4",
+    "version": "6.6.5",
     "description": "Write everything faster.",
     "main": "index.js",
     "scripts": {

--- a/src/background/js/controllers/includes/template_form.js
+++ b/src/background/js/controllers/includes/template_form.js
@@ -267,7 +267,13 @@ export default function TemplateFormCtrl ($route, $q, $scope, $rootScope, $route
                 });
 
                 self.extended = false;
-                $('#template-form-modal').modal('show');
+                var $templateFormModal = $('#template-form-modal');
+                // HACK changes to jQuery.show in 3.x conflict with Bootstrap 3.x Modal.
+                // these prevent setting display: block on the modal sometimes
+                // when trying to open the modal from the url directly
+                // (eg. when clicking New Template in the Templates Dialog).
+                $templateFormModal.css('display', 'block');
+                $templateFormModal.modal('show');
             };
 
             if (id == "new") {

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,7 +1,7 @@
 {
     "manifest_version": 2,
     "name": "__MSG_extName__",
-    "version": "6.6.4",
+    "version": "6.6.5",
     "description": "__MSG_extDesc__",
     "short_name": "Gorgias",
     "default_locale": "en",


### PR DESCRIPTION
* When pressing New Template or Edit Template in the content script Templates Dialog, sometimes the New/Edit Template dialog would not open. The modal backdrop would be visible, but not the modal content.
* This would only happen in the production build (when running `webpack -p`).
* It's probably caused by a conflict between jQuery 3.x's `show()` changes and Bootstrap 3.x's Modal.
* Fix it by forcing `display: block` on the modal before opening it with `modal('show')`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gorgias/gorgias-chrome/361)
<!-- Reviewable:end -->
