### PR TITLE
Fix issues with not being able to log-in after Firestore upgrade

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "gorgias",
-    "version": "6.6.7",
+    "version": "6.6.8",
     "description": "Write everything faster.",
     "main": "index.js",
     "scripts": {

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,7 +1,7 @@
 {
     "manifest_version": 2,
     "name": "__MSG_extName__",
-    "version": "6.6.7",
+    "version": "6.6.8",
     "description": "__MSG_extDesc__",
     "short_name": "Gorgias",
     "default_locale": "en",

--- a/src/store/plugin-firestore.js
+++ b/src/store/plugin-firestore.js
@@ -16,10 +16,6 @@ firebase.initializeApp(firebaseConfig);
 var db = firebase.firestore();
 var storageRef = firebase.storage().ref();
 
-db.enablePersistence().catch((err) => {
-    console.log('Firestore Persistance Error', err);
-});
-
 function mock () {
     return Promise.resolve();
 }


### PR DESCRIPTION
* Fix issues with Firestore throwing "AsyncQueue is already failed" errors when trying to log-in, and preventing log-in.
* Disable the Firestore persistence cache for now. The IndexedDB cache is probably incompatible between versions and just throws an error.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gorgias/gorgias-chrome/363)
<!-- Reviewable:end -->
