### PR TITLE
Empty template extra fields

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "gorgias",
-    "version": "6.6.13",
+    "version": "6.6.14",
     "description": "Write everything faster.",
     "main": "index.js",
     "scripts": {

--- a/src/background/js/controllers/includes/template_form.js
+++ b/src/background/js/controllers/includes/template_form.js
@@ -327,14 +327,6 @@ export default function TemplateFormCtrl ($route, $q, $scope, $rootScope, $route
                 return false;
             }
 
-            // delete extra fields with blank values,
-            // to not show them again on edit.
-            extraFields.forEach(function (field) {
-                if (typeof self.selectedTemplate[field] === 'string' && self.selectedTemplate[field].trim() === '') {
-                    delete self.selectedTemplate[field];
-                }
-            });
-
             TemplateService.quicktexts().then(function (templates) {
                 if (self.selectedTemplate.shortcut) {
                     for (var i in templates) {

--- a/src/background/js/controllers/includes/template_form.js
+++ b/src/background/js/controllers/includes/template_form.js
@@ -223,8 +223,8 @@ export default function TemplateFormCtrl ($route, $q, $scope, $rootScope, $route
                                 self.selectedTemplate.tags = tags;
                             });
                         }
-
                     });
+
                     var defaults = {
                         'id': '',
                         'remote_id': '',
@@ -283,7 +283,7 @@ export default function TemplateFormCtrl ($route, $q, $scope, $rootScope, $route
             };
 
             if (id == "new") {
-                self.selectedTemplate = null;
+                self.selectedTemplate = {};
 
                 if ($scope.account) {
                     $scope.initializeMemberSelectize([self.selectedTemplate]).then(function () {

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,7 +1,7 @@
 {
     "manifest_version": 2,
     "name": "__MSG_extName__",
-    "version": "6.6.13",
+    "version": "6.6.14",
     "description": "__MSG_extDesc__",
     "short_name": "Gorgias",
     "default_locale": "en",


### PR DESCRIPTION
* Fix issues with not being able to empty template extra fields (subject, to, cc, bcc), after having a value.
* Fix errors thrown when initializing the `selectize` tag selector on New Template.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gorgias/gorgias-chrome/373)
<!-- Reviewable:end -->
