### PR TITLE
CRM content plugin with custom variable support

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "gorgias",
-    "version": "6.6.15",
+    "version": "6.7.0",
     "description": "Write everything faster.",
     "main": "index.js",
     "scripts": {

--- a/src/content/js/autocomplete.js
+++ b/src/content/js/autocomplete.js
@@ -14,6 +14,7 @@ import yahooPlugin from './plugins/yahoo';
 import zendeskPlugin from './plugins/zendesk';
 import draftPlugin from './plugins/draft';
 import prosemirrorPlugin from './plugins/prosemirror';
+import crmPlugin from './plugins/crm';
 import genericPlugin from './plugins/generic';
 
 var autocomplete = {};
@@ -246,6 +247,7 @@ register(yahooPlugin);
 register(zendeskPlugin);
 register(draftPlugin);
 register(prosemirrorPlugin);
+register(crmPlugin);
 register(genericPlugin);
 
 export default autocomplete;

--- a/src/content/js/plugins/crm.js
+++ b/src/content/js/plugins/crm.js
@@ -1,0 +1,34 @@
+/* CRM plugin
+ */
+
+import {insertText, parseTemplate} from '../utils';
+
+const attributeVariables = 'data-gorgias-variables';
+
+function isActive (element) {
+    return element && element.hasAttribute(attributeVariables);
+}
+
+function decodeAttribute (attr = '') {
+    return JSON.parse(decodeURIComponent(attr));
+}
+
+function getData (element) {
+    const value = element.getAttribute(attributeVariables);
+    return decodeAttribute(value);
+}
+
+export default (params = {}) => {
+    if (!isActive(params.element)) {
+        return false;
+    }
+
+    var data = getData(params.element);
+    var parsedTemplate = parseTemplate(params.quicktext.body, data);
+
+    insertText(Object.assign({
+        text: parsedTemplate
+    }, params));
+
+    return true;
+};

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,7 +1,7 @@
 {
     "manifest_version": 2,
     "name": "__MSG_extName__",
-    "version": "6.6.15",
+    "version": "6.7.0",
     "description": "__MSG_extDesc__",
     "short_name": "Gorgias",
     "default_locale": "en",


### PR DESCRIPTION
* Content plugin for CRMs where we have access to the HTML markup.
* Allows us to use custom variables.
* Requires an HTML attribute on the input element: `data-gorgias-variables`.
* Value must be a stringified JSON, then URI encoded:
```
$textarea.setAttribute('data-gorgias-variables', encodeURIComponent(JSON.stringify({})))
```
* The decoded object is passed to the handlebars template.