### PR TITLE
Improvements to enabling quick action button

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "gorgias",
-    "version": "6.7.0",
+    "version": "6.7.1",
     "description": "Write everything faster.",
     "main": "index.js",
     "scripts": {

--- a/src/content/js/dialog.js
+++ b/src/content/js/dialog.js
@@ -10,6 +10,7 @@ import Mousetrap from 'mousetrap';
 import PubSub from './patterns';
 import store from '../../store/store-client';
 import autocomplete from './autocomplete';
+import {isQuickButtonEnabled} from './utils';
 
 var KEY_UP = 38;
 var KEY_DOWN = 40;
@@ -31,10 +32,6 @@ var dialog = {
     RESULTS_LIMIT: 5, // only show 5 results at a time
     editor: null,
     qaBtn: null,
-    qaBtnWhitelist: [
-        'https://mail.google.com',
-        'https://inbox.google.com'
-    ],
     prevFocus: null,
     dialogSelector: ".qt-dropdown",
     contentSelector: ".qt-dropdown-content",
@@ -149,12 +146,23 @@ var dialog = {
             window.open(templateUrl, 'gorgias-options');
         });
     },
-    createQaBtn: function () {
-        // only on whitelisted domains
-        if (!dialog.qaBtnWhitelist.includes(window.location.origin)) {
-            return;
+    setupQuickButton: function () {
+        if (isQuickButtonEnabled()) {
+            return dialog.createQaBtn();
         }
 
+        const domObserver = new MutationObserver((records, observer) => {
+            if (isQuickButtonEnabled()) {
+                observer.disconnect();
+
+                dialog.createQaBtn();
+            }
+        });
+        domObserver.observe(document.body, {
+            attributes: true
+        });
+    },
+    createQaBtn: function () {
         var container = $('body');
 
         var instance = this;

--- a/src/content/js/index.js
+++ b/src/content/js/index.js
@@ -256,7 +256,7 @@ App.init = function(settings, doc) {
         !isContentEditable
     ) {
         if (settings.qaBtn.enabled) {
-            dialog.createQaBtn();
+            dialog.setupQuickButton();
         }
         if (settings.dialog.limit) {
             dialog.RESULTS_LIMIT = settings.dialog.limit;

--- a/src/content/js/plugins/gmail.js
+++ b/src/content/js/plugins/gmail.js
@@ -3,7 +3,7 @@
 
 import $ from 'jquery';
 
-import {insertText, parseTemplate, isContentEditable} from '../utils';
+import {insertText, parseTemplate, isContentEditable, enableQuickButton} from '../utils';
 
 function parseList (list) {
     return list.filter(function (a) {
@@ -306,6 +306,16 @@ function isActive () {
 
     return activeCache;
 }
+
+function setup () {
+    if (!isActive()) {
+        return false;
+    }
+
+    enableQuickButton();
+}
+
+setup();
 
 export default (params = {}) => {
     if (!isActive()) {

--- a/src/content/js/utils.js
+++ b/src/content/js/utils.js
@@ -326,3 +326,10 @@ export function parseUserDetails (title) {
     return $.extend(details, splitFullName(details.name));
 }
 
+export function enableQuickButton () {
+    document.body.dataset.gorgiasButton = 'true';
+}
+
+export function isQuickButtonEnabled () {
+    return !!document.body.dataset.gorgiasButton;
+}

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,7 +1,7 @@
 {
     "manifest_version": 2,
     "name": "__MSG_extName__",
-    "version": "6.7.0",
+    "version": "6.7.1",
     "description": "__MSG_extDesc__",
     "short_name": "Gorgias",
     "default_locale": "en",


### PR DESCRIPTION
* Enable the quick action button by setting a data attribute (`data-gorgias-button`) on the `body` element.
* Allows us to enable the button from plugins (Gmail) and from custom CRMs.
* Remove the quick action button url whitelist.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gorgias/gorgias-chrome/377)
<!-- Reviewable:end -->
