### PR TITLE
Fix security issue with the option page being embedded

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "gorgias",
-    "version": "6.7.1",
+    "version": "6.7.2",
     "description": "Write everything faster.",
     "main": "index.js",
     "scripts": {

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -49,5 +49,5 @@
             "38": "icons/icon38.png"
         }
     },
-    "content_security_policy": "script-src 'self' https://d24n15hnbwhuhn.cloudfront.net https://checkout.stripe.com/checkout.js https://js.stripe.com/v3/; object-src 'self'"
+    "content_security_policy": "script-src 'self' https://d24n15hnbwhuhn.cloudfront.net https://checkout.stripe.com/checkout.js https://js.stripe.com/v3/; object-src 'self'; frame-ancestors 'none'"
 }

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,7 +1,7 @@
 {
     "manifest_version": 2,
     "name": "__MSG_extName__",
-    "version": "6.7.1",
+    "version": "6.7.2",
     "description": "__MSG_extDesc__",
     "short_name": "Gorgias",
     "default_locale": "en",


### PR DESCRIPTION
* Add `frame-ancestors 'none'` to the CSP, to prevent the options page from being embedded.
* Fixes possible clickjacking security issues.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gorgias/gorgias-chrome/378)
<!-- Reviewable:end -->
