### PR TITLE
Improvements to bubble positioning

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "briskine",
-  "version": "7.16.11",
+  "version": "7.16.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "briskine",
-      "version": "7.16.11",
+      "version": "7.16.12",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "@floating-ui/dom": "^1.7.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "briskine",
-  "version": "7.16.11",
+  "version": "7.16.12",
   "description": "Write everything faster.",
   "private": true,
   "type": "module",

--- a/src/content/bubble/bubble.js
+++ b/src/content/bubble/bubble.js
@@ -201,24 +201,52 @@ function isComposedAncestor (ancestor, element) {
 // detect if something is covering the x,y coords where we want to place the bubble.
 // in case there's another element on the top-end side of the textfield
 // (e.g., gmail when we compose a new email while replying in an existing thread).
+// if covered, shifts the bubble toward the center of the textfield until a clear spot is found.
 function occlusionHide (textfield) {
   return {
     name: 'occlusionHide',
     fn ({ x, y, middlewareData }) {
       if (middlewareData.hide?.referenceHidden) {
-        return { data: { hidden: true } }
+        return {
+          data: { hidden: true },
+        }
       }
 
-      const elements = document.elementsFromPoint(x + bubbleSize / 2, y + bubbleSize / 2)
-      const top = elements.find(el => el !== bubbleInstance)
-      const hidden = (
-        !!top
-        // if the textfield is in a shadow root
-        && !isComposedAncestor(top, textfield)
-        && !textfield.contains(top)
-      )
+      // top-end is on the right in ltr and on the left in rtl,
+      // so shift toward center in each case.
+      const isRtl = getComputedStyle(textfield).direction === 'rtl'
+      const stepDirection = isRtl ? 1 : -1
+      const textfieldRect = textfield.getBoundingClientRect()
 
-      return { data: { hidden } }
+      let currentX = x
+      let shifted = false
+
+      // when shifting, the bubble must stay within the bounds of the textfield
+      while (isRtl ? currentX + bubbleSize <= textfieldRect.right : currentX >= textfieldRect.left) {
+        const elements = document.elementsFromPoint(currentX + bubbleSize / 2, y + bubbleSize / 2)
+        const top = elements.find(el => el !== bubbleInstance)
+        const occluded = (
+          !!top
+          // if the textfield is in a shadow root
+          && !isComposedAncestor(top, textfield)
+          && !textfield.contains(top)
+        )
+
+        if (!occluded) {
+          // when shifted, offset() margin no longer applies on the trailing side,
+          // so add it back manually to keep the gap from the occluding element.
+          const finalX = shifted ? currentX + stepDirection * bubbleMargin : currentX
+          return {
+            x: finalX,
+            data: { hidden: false },
+          }
+        }
+
+        currentX += stepDirection * bubbleSize
+        shifted = true
+      }
+
+      return { data: { hidden: true } }
     },
   }
 }

--- a/src/content/bubble/bubble.js
+++ b/src/content/bubble/bubble.js
@@ -202,10 +202,10 @@ function isComposedAncestor (ancestor, element) {
 // in case there's another element on the top-end side of the textfield
 // (e.g., gmail when we compose a new email while replying in an existing thread).
 // if covered, shifts the bubble toward the center of the textfield until a clear spot is found.
-function occlusionHide (textfield) {
+function occlusionHide (textfield, isRtl) {
   return {
     name: 'occlusionHide',
-    fn ({ x, y, middlewareData }) {
+    fn ({ x, y, rects, middlewareData }) {
       if (middlewareData.hide?.referenceHidden) {
         return {
           data: { hidden: true },
@@ -214,15 +214,15 @@ function occlusionHide (textfield) {
 
       // top-end is on the right in ltr and on the left in rtl,
       // so shift toward center in each case.
-      const isRtl = getComputedStyle(textfield).direction === 'rtl'
       const stepDirection = isRtl ? 1 : -1
-      const textfieldRect = textfield.getBoundingClientRect()
+      const textfieldLeft = rects.reference.x
+      const textfieldRight = rects.reference.x + rects.reference.width
 
       let currentX = x
       let shifted = false
 
       // when shifting, the bubble must stay within the bounds of the textfield
-      while (isRtl ? currentX + bubbleSize <= textfieldRect.right : currentX >= textfieldRect.left) {
+      while (isRtl ? currentX + bubbleSize <= textfieldRight : currentX >= textfieldLeft) {
         const elements = document.elementsFromPoint(currentX + bubbleSize / 2, y + bubbleSize / 2)
         const top = elements.find(el => el !== bubbleInstance)
         const occluded = (
@@ -258,6 +258,8 @@ function showBubble (textfield) {
 
   bubbleInstance.setAttribute('visible', 'true')
 
+  const isRtl = getComputedStyle(textfield).direction === 'rtl'
+
   const middleware = [
     offset({
       mainAxis: -1 * (bubbleSize + bubbleMargin),
@@ -274,7 +276,7 @@ function showBubble (textfield) {
       elementContext: 'reference',
     }),
     hide(),
-    occlusionHide(textfield),
+    occlusionHide(textfield, isRtl),
   ]
 
   cleanupFloatingUi()

--- a/src/content/bubble/bubble.spec.js
+++ b/src/content/bubble/bubble.spec.js
@@ -198,6 +198,55 @@ describe('bubble', () => {
       })
     })
 
+    it('shifts left in ltr and stays visible when initial position is covered', async () => {
+      const textarea = createTextarea()
+      const coveringElement = document.createElement('div')
+      document.body.appendChild(coveringElement)
+
+      vi.spyOn(document, 'elementsFromPoint')
+        .mockImplementationOnce(() => [coveringElement, document.body, document.documentElement])
+        .mockImplementation(() => [textarea, document.body, document.documentElement])
+
+      textarea.focus()
+
+      await vi.waitFor(() => {
+        const bubble = getBubble()
+        const textareaRect = textarea.getBoundingClientRect()
+        const bubbleLeft = parseInt(bubble.style.left)
+        expect(bubble.hasAttribute('visible')).toBe(true)
+        expect(bubble.style.visibility).toBe('visible')
+        expect(bubbleLeft).toBeGreaterThanOrEqual(textareaRect.left)
+        expect(bubbleLeft).toBeLessThan(textareaRect.right)
+      })
+
+      coveringElement.remove()
+    })
+
+    it('shifts right in rtl and stays visible when initial position is covered', async () => {
+      const textarea = createTextarea()
+      textarea.style.direction = 'rtl'
+      const coveringElement = document.createElement('div')
+      document.body.appendChild(coveringElement)
+
+      vi.spyOn(document, 'elementsFromPoint')
+        .mockImplementationOnce(() => [coveringElement, document.body, document.documentElement])
+        .mockImplementation(() => [textarea, document.body, document.documentElement])
+
+      textarea.focus()
+
+      await vi.waitFor(() => {
+        const bubble = getBubble()
+        const textareaRect = textarea.getBoundingClientRect()
+        const bubbleLeft = parseInt(bubble.style.left)
+        expect(bubble.hasAttribute('visible')).toBe(true)
+        expect(bubble.style.visibility).toBe('visible')
+        expect(bubbleLeft).toBeGreaterThanOrEqual(textareaRect.left)
+        expect(bubbleLeft).toBeLessThan(textareaRect.right)
+      })
+
+      coveringElement.remove()
+    })
+
     it('does not hide when covered by the shadow host of the textfield', async () => {
       const host = document.createElement('div')
       Object.assign(host.style, {

--- a/src/content/dialog/dialog.js
+++ b/src/content/dialog/dialog.js
@@ -130,8 +130,10 @@ function Dialog (originalProps) {
 
     setVisible(true)
     const position = getDialogPosition(target, element, placement)
-    element.style.top = `${position.top}px`
-    element.style.left = `${position.left}px`
+    Object.assign(element.style, {
+      top: `${position.top}px`,
+      left: `${position.left}px`,
+    })
 
     // clean-up the virtual caret mirror,
     // used on input and textarea


### PR DESCRIPTION
* Improve bubble positioning.
* When the intended bubble position is occluded (something else is covering up the textfield, a different extension added an element in the same position, etc.) try to move the bubble towards the x-center of the textfield until it finds an available position.